### PR TITLE
Fix availableLanguage warning on AutomotiveBusiness schema

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -81,7 +81,16 @@ const businessSchema = {
     }
   ],
   "priceRange": "$$",
-  "availableLanguage": ["en", "es"],
+  "contactPoint": {
+    "@type": "ContactPoint",
+    "telephone": "+1-754-215-2272",
+    "email": "contact@route95mobilecardetailing.com",
+    "contactType": "customer service",
+    "availableLanguage": [
+      { "@type": "Language", "name": "English", "alternateName": "en" },
+      { "@type": "Language", "name": "Spanish", "alternateName": "es" }
+    ]
+  },
   "founder": {
     "@type": "Person",
     "name": "Gustavo Moya"


### PR DESCRIPTION
Move availableLanguage from AutomotiveBusiness (where it's not a recognized property) into a ContactPoint object where schema.org supports it. Uses proper Language type objects with name/alternateName.

https://claude.ai/code/session_01LTqWyhsDRvkudQKXSoXj4b