### PR TITLE
Fix URL canonicalization: change canonical domain from www to non-www

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,7 +5,7 @@ import sitemap from '@astrojs/sitemap';
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://www.route95mobilecardetailing.com',
+  site: 'https://route95mobilecardetailing.com',
   base: '/',
   output: 'static',
   trailingSlash: 'always',

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,1 @@
-www.route95mobilecardetailing.com
+route95mobilecardetailing.com

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,4 +1,4 @@
 User-agent: *
 Allow: /
 
-Sitemap: https://www.route95mobilecardetailing.com/sitemap-index.xml
+Sitemap: https://route95mobilecardetailing.com/sitemap-index.xml

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -18,7 +18,7 @@ const { title, description, currentPage = '', schema } = Astro.props;
 const locale = (Astro.currentLocale ?? 'en') as Locale;
 const t = getTranslations(locale);
 
-const siteUrl = 'https://www.route95mobilecardetailing.com';
+const siteUrl = 'https://route95mobilecardetailing.com';
 const enUrl = getAlternateUrl(Astro.url, 'en');
 const esUrl = getAlternateUrl(Astro.url, 'es');
 
@@ -59,10 +59,10 @@ const areaServed = [
 const businessSchema = {
   "@context": "https://schema.org",
   "@type": "AutomotiveBusiness",
-  "@id": "https://www.route95mobilecardetailing.com/#business",
+  "@id": "https://route95mobilecardetailing.com/#business",
   "name": "Route95 Mobile Car Detailing LLC",
   "description": "Professional mobile car detailing in Fort Lauderdale. We come to you with premium products from Chemical Guys, Koch-Chemie & 3D. Serving Fort Lauderdale, Dania Beach, Hollywood & Pompano Beach.",
-  "image": "https://www.route95mobilecardetailing.com/logo-transparent.png",
+  "image": "https://route95mobilecardetailing.com/logo-transparent.png",
   "telephone": "+1-754-215-2272",
   "email": "contact@route95mobilecardetailing.com",
   "address": businessAddress,
@@ -71,7 +71,7 @@ const businessSchema = {
     "latitude": 26.1224,
     "longitude": -80.1373
   },
-  "url": "https://www.route95mobilecardetailing.com",
+  "url": "https://route95mobilecardetailing.com",
   "openingHoursSpecification": [
     {
       "@type": "OpeningHoursSpecification",
@@ -105,17 +105,17 @@ const businessSchema = {
       {
         "@type": "OfferCatalog",
         "name": "Car Wash Services",
-        "url": "https://www.route95mobilecardetailing.com/car-wash-fort-lauderdale/"
+        "url": "https://route95mobilecardetailing.com/car-wash-fort-lauderdale/"
       },
       {
         "@type": "OfferCatalog",
         "name": "Upholstery Cleaning Services",
-        "url": "https://www.route95mobilecardetailing.com/upholstery-cleaning-fort-lauderdale/"
+        "url": "https://route95mobilecardetailing.com/upholstery-cleaning-fort-lauderdale/"
       },
       {
         "@type": "OfferCatalog",
         "name": "Car Detailing Packages",
-        "url": "https://www.route95mobilecardetailing.com/car-detailing-services-fort-lauderdale/"
+        "url": "https://route95mobilecardetailing.com/car-detailing-services-fort-lauderdale/"
       }
     ]
   },
@@ -126,11 +126,11 @@ const businessSchema = {
 const organizationSchema = {
   "@context": "https://schema.org",
   "@type": "Organization",
-  "@id": "https://www.route95mobilecardetailing.com/#organization",
+  "@id": "https://route95mobilecardetailing.com/#organization",
   "name": "Route95 Mobile Car Detailing LLC",
-  "url": "https://www.route95mobilecardetailing.com",
-  "logo": "https://www.route95mobilecardetailing.com/logo-transparent.png",
-  "image": "https://www.route95mobilecardetailing.com/logo-transparent.png",
+  "url": "https://route95mobilecardetailing.com",
+  "logo": "https://route95mobilecardetailing.com/logo-transparent.png",
+  "image": "https://route95mobilecardetailing.com/logo-transparent.png",
   "description": "Professional mobile car detailing service in Broward County, Florida. We bring premium auto detailing directly to your location in Fort Lauderdale, Dania Beach, Hollywood, and Pompano Beach.",
   "telephone": "+1-754-215-2272",
   "email": "contact@route95mobilecardetailing.com",

--- a/src/pages/bug-and-tar-removal-fort-lauderdale.astro
+++ b/src/pages/bug-and-tar-removal-fort-lauderdale.astro
@@ -11,7 +11,7 @@ const parentCategory = {
   title: "Car Wash Services"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/car-detailing-services-fort-lauderdale.astro
+++ b/src/pages/car-detailing-services-fort-lauderdale.astro
@@ -6,7 +6,7 @@ const base = import.meta.env.BASE_URL;
 const title = "Car Detailing Services Fort Lauderdale | Mobile | Route95";
 const description = "Mobile car detailing packages in Fort Lauderdale. Quick Wash, Fresh Start, Complete Clean & Premium Refresh. Compare packages, add-ons & pricing. Call 754-215-2272.";
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const categorySchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/car-wash-fort-lauderdale.astro
+++ b/src/pages/car-wash-fort-lauderdale.astro
@@ -6,7 +6,7 @@ const base = import.meta.env.BASE_URL;
 const title = "Car Wash Fort Lauderdale | Mobile Service | Route95";
 const description = "Mobile car wash in Fort Lauderdale. We come to your home or office with all equipment. Hand wash, waxing, clay bar, wheel cleaning. Same-day available. Call 754-215-2272.";
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const categorySchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/car-waxing-fort-lauderdale.astro
+++ b/src/pages/car-waxing-fort-lauderdale.astro
@@ -11,7 +11,7 @@ const parentCategory = {
   title: "Car Wash Services"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/carpet-shampooing-fort-lauderdale.astro
+++ b/src/pages/carpet-shampooing-fort-lauderdale.astro
@@ -11,7 +11,7 @@ const parentCategory = {
   title: "Upholstery Cleaning Services"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/chrome-polishing-fort-lauderdale.astro
+++ b/src/pages/chrome-polishing-fort-lauderdale.astro
@@ -11,7 +11,7 @@ const parentCategory = {
   title: "Car Wash Services"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/clay-bar-treatment-fort-lauderdale.astro
+++ b/src/pages/clay-bar-treatment-fort-lauderdale.astro
@@ -11,7 +11,7 @@ const parentCategory = {
   title: "Car Wash Services"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/complete-clean-fort-lauderdale.astro
+++ b/src/pages/complete-clean-fort-lauderdale.astro
@@ -11,7 +11,7 @@ const parentCategory = {
   title: "Car Detailing Services"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 
 const serviceSchema = {
   "@context": "https://schema.org",

--- a/src/pages/dashboard-cleaning-fort-lauderdale.astro
+++ b/src/pages/dashboard-cleaning-fort-lauderdale.astro
@@ -11,7 +11,7 @@ const parentCategory = {
   title: "Upholstery Cleaning Services"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/es/acondicionador-de-llantas-fort-lauderdale.astro
+++ b/src/pages/es/acondicionador-de-llantas-fort-lauderdale.astro
@@ -12,7 +12,7 @@ const parentCategory = {
   title: "Servicios de Lavado"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/es/acondicionamiento-de-cuero-fort-lauderdale.astro
+++ b/src/pages/es/acondicionamiento-de-cuero-fort-lauderdale.astro
@@ -12,7 +12,7 @@ const parentCategory = {
   title: "Limpieza de Tapicería"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/es/aspirado-interior-fort-lauderdale.astro
+++ b/src/pages/es/aspirado-interior-fort-lauderdale.astro
@@ -12,7 +12,7 @@ const parentCategory = {
   title: "Limpieza de Tapicería"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/es/eliminacion-de-insectos-y-alquitran-fort-lauderdale.astro
+++ b/src/pages/es/eliminacion-de-insectos-y-alquitran-fort-lauderdale.astro
@@ -12,7 +12,7 @@ const parentCategory = {
   title: "Servicios de Lavado"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/es/eliminacion-de-manchas-de-agua-fort-lauderdale.astro
+++ b/src/pages/es/eliminacion-de-manchas-de-agua-fort-lauderdale.astro
@@ -12,7 +12,7 @@ const parentCategory = {
   title: "Servicios de Lavado"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/es/eliminacion-de-olor-a-humo-fort-lauderdale.astro
+++ b/src/pages/es/eliminacion-de-olor-a-humo-fort-lauderdale.astro
@@ -12,7 +12,7 @@ const parentCategory = {
   title: "Limpieza de Tapiceria"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/es/eliminacion-de-olores-fort-lauderdale.astro
+++ b/src/pages/es/eliminacion-de-olores-fort-lauderdale.astro
@@ -12,7 +12,7 @@ const parentCategory = {
   title: "Limpieza de Tapicería"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/es/eliminacion-de-pelo-de-mascota-fort-lauderdale.astro
+++ b/src/pages/es/eliminacion-de-pelo-de-mascota-fort-lauderdale.astro
@@ -12,7 +12,7 @@ const parentCategory = {
   title: "Limpieza de Tapicería"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/es/encerado-de-autos-fort-lauderdale.astro
+++ b/src/pages/es/encerado-de-autos-fort-lauderdale.astro
@@ -12,7 +12,7 @@ const parentCategory = {
   title: "Servicios de Lavado"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -50,10 +50,10 @@ const websiteSchema = {
   "@context": "https://schema.org",
   "@type": "WebSite",
   "name": "Route95 Mobile Car Detailing",
-  "url": "https://www.route95mobilecardetailing.com/",
+  "url": "https://route95mobilecardetailing.com/",
   "description": "Detallado profesional de autos a domicilio en Fort Lauderdale. ¡Vamos a ti!",
   "publisher": {
-    "@id": "https://www.route95mobilecardetailing.com/#business"
+    "@id": "https://route95mobilecardetailing.com/#business"
   },
   "inLanguage": ["en-US", "es-ES"]
 };

--- a/src/pages/es/lavado-a-mano-fort-lauderdale.astro
+++ b/src/pages/es/lavado-a-mano-fort-lauderdale.astro
@@ -12,7 +12,7 @@ const parentCategory = {
   title: "Servicios de Lavado"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/es/lavado-de-alfombras-fort-lauderdale.astro
+++ b/src/pages/es/lavado-de-alfombras-fort-lauderdale.astro
@@ -12,7 +12,7 @@ const parentCategory = {
   title: "Limpieza de Tapicería"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/es/lavado-de-asientos-fort-lauderdale.astro
+++ b/src/pages/es/lavado-de-asientos-fort-lauderdale.astro
@@ -12,7 +12,7 @@ const parentCategory = {
   title: "Limpieza de Tapicería"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/es/lavado-de-autos-fort-lauderdale.astro
+++ b/src/pages/es/lavado-de-autos-fort-lauderdale.astro
@@ -7,7 +7,7 @@ const base = import.meta.env.BASE_URL;
 const title = "Lavado de Autos Fort Lauderdale | Servicio Móvil | Route95";
 const description = "Lavado de autos a domicilio en Fort Lauderdale. Vamos a tu casa u oficina con todo el equipo. Lavado a mano, encerado, barra de arcilla, limpieza de rines. Mismo día disponible. Llama al 754-215-2272.";
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const categorySchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/es/lavado-rapido-fort-lauderdale.astro
+++ b/src/pages/es/lavado-rapido-fort-lauderdale.astro
@@ -12,7 +12,7 @@ const parentCategory = {
   title: "Servicios de Detallado"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 
 const serviceSchema = {
   "@context": "https://schema.org",

--- a/src/pages/es/limpieza-a-vapor-fort-lauderdale.astro
+++ b/src/pages/es/limpieza-a-vapor-fort-lauderdale.astro
@@ -12,7 +12,7 @@ const parentCategory = {
   title: "Limpieza de Tapicería"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/es/limpieza-completa-fort-lauderdale.astro
+++ b/src/pages/es/limpieza-completa-fort-lauderdale.astro
@@ -12,7 +12,7 @@ const parentCategory = {
   title: "Servicios de Detallado"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 
 const serviceSchema = {
   "@context": "https://schema.org",

--- a/src/pages/es/limpieza-de-cuero-fort-lauderdale.astro
+++ b/src/pages/es/limpieza-de-cuero-fort-lauderdale.astro
@@ -12,7 +12,7 @@ const parentCategory = {
   title: "Limpieza de Tapicería"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/es/limpieza-de-rines-fort-lauderdale.astro
+++ b/src/pages/es/limpieza-de-rines-fort-lauderdale.astro
@@ -12,7 +12,7 @@ const parentCategory = {
   title: "Servicios de Lavado"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/es/limpieza-de-tablero-fort-lauderdale.astro
+++ b/src/pages/es/limpieza-de-tablero-fort-lauderdale.astro
@@ -12,7 +12,7 @@ const parentCategory = {
   title: "Servicios de Detallado"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/es/limpieza-de-tapiceria-fort-lauderdale.astro
+++ b/src/pages/es/limpieza-de-tapiceria-fort-lauderdale.astro
@@ -7,7 +7,7 @@ const base = import.meta.env.BASE_URL;
 const title = "Limpieza de Tapicería Fort Lauderdale | Servicio Móvil | Route95";
 const description = "Limpieza de tapicería a domicilio en Fort Lauderdale. Asientos, alfombras, cuero, eliminación de olores. Vamos a ti con equipo profesional. Mismo día disponible. Llama al 754-215-2272.";
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const categorySchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/es/nuevo-comienzo-fort-lauderdale.astro
+++ b/src/pages/es/nuevo-comienzo-fort-lauderdale.astro
@@ -12,7 +12,7 @@ const parentCategory = {
   title: "Servicios de Detallado"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 
 const serviceSchema = {
   "@context": "https://schema.org",

--- a/src/pages/es/proteccion-de-tela-fort-lauderdale.astro
+++ b/src/pages/es/proteccion-de-tela-fort-lauderdale.astro
@@ -12,7 +12,7 @@ const parentCategory = {
   title: "Limpieza de Tapiceria"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/es/proteccion-interior-fort-lauderdale.astro
+++ b/src/pages/es/proteccion-interior-fort-lauderdale.astro
@@ -12,7 +12,7 @@ const parentCategory = {
   title: "Servicios de Detallado"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/es/pulido-de-cromo-fort-lauderdale.astro
+++ b/src/pages/es/pulido-de-cromo-fort-lauderdale.astro
@@ -12,7 +12,7 @@ const parentCategory = {
   title: "Servicios de Lavado"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/es/renovacion-premium-fort-lauderdale.astro
+++ b/src/pages/es/renovacion-premium-fort-lauderdale.astro
@@ -11,7 +11,7 @@ const parentCategory = {
   title: "Servicios de Detallado"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 
 const serviceSchema = {
   "@context": "https://schema.org",

--- a/src/pages/es/restauracion-de-molduras-fort-lauderdale.astro
+++ b/src/pages/es/restauracion-de-molduras-fort-lauderdale.astro
@@ -12,7 +12,7 @@ const parentCategory = {
   title: "Servicios de Lavado"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/es/servicios-de-detallado-fort-lauderdale.astro
+++ b/src/pages/es/servicios-de-detallado-fort-lauderdale.astro
@@ -85,7 +85,7 @@ const addOns = [
   { name: "Encerado de Autos", price: 60, from: true }
 ];
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const categorySchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/es/tratamiento-barra-de-arcilla-fort-lauderdale.astro
+++ b/src/pages/es/tratamiento-barra-de-arcilla-fort-lauderdale.astro
@@ -12,7 +12,7 @@ const parentCategory = {
   title: "Servicios de Lavado"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/fabric-protection-fort-lauderdale.astro
+++ b/src/pages/fabric-protection-fort-lauderdale.astro
@@ -11,7 +11,7 @@ const parentCategory = {
   title: "Upholstery Cleaning Services"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/fresh-start-fort-lauderdale.astro
+++ b/src/pages/fresh-start-fort-lauderdale.astro
@@ -11,7 +11,7 @@ const parentCategory = {
   title: "Car Detailing Services"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 
 const serviceSchema = {
   "@context": "https://schema.org",

--- a/src/pages/hand-wash-fort-lauderdale.astro
+++ b/src/pages/hand-wash-fort-lauderdale.astro
@@ -11,7 +11,7 @@ const parentCategory = {
   title: "Car Wash Services"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -49,10 +49,10 @@ const websiteSchema = {
   "@context": "https://schema.org",
   "@type": "WebSite",
   "name": "Route95 Mobile Car Detailing",
-  "url": "https://www.route95mobilecardetailing.com/",
+  "url": "https://route95mobilecardetailing.com/",
   "description": "Professional mobile car detailing in Fort Lauderdale. We come to you!",
   "publisher": {
-    "@id": "https://www.route95mobilecardetailing.com/#business"
+    "@id": "https://route95mobilecardetailing.com/#business"
   },
   "inLanguage": ["en-US", "es-ES"]
 };

--- a/src/pages/interior-protection-fort-lauderdale.astro
+++ b/src/pages/interior-protection-fort-lauderdale.astro
@@ -11,7 +11,7 @@ const parentCategory = {
   title: "Upholstery Cleaning Services"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/interior-vacuuming-fort-lauderdale.astro
+++ b/src/pages/interior-vacuuming-fort-lauderdale.astro
@@ -11,7 +11,7 @@ const parentCategory = {
   title: "Upholstery Cleaning Services"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/leather-cleaning-fort-lauderdale.astro
+++ b/src/pages/leather-cleaning-fort-lauderdale.astro
@@ -11,7 +11,7 @@ const parentCategory = {
   title: "Upholstery Cleaning Services"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/leather-conditioning-fort-lauderdale.astro
+++ b/src/pages/leather-conditioning-fort-lauderdale.astro
@@ -11,7 +11,7 @@ const parentCategory = {
   title: "Upholstery Cleaning Services"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/odor-removal-fort-lauderdale.astro
+++ b/src/pages/odor-removal-fort-lauderdale.astro
@@ -11,7 +11,7 @@ const parentCategory = {
   title: "Upholstery Cleaning Services"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/pet-hair-removal-fort-lauderdale.astro
+++ b/src/pages/pet-hair-removal-fort-lauderdale.astro
@@ -11,7 +11,7 @@ const parentCategory = {
   title: "Upholstery Cleaning Services"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/premium-refresh-fort-lauderdale.astro
+++ b/src/pages/premium-refresh-fort-lauderdale.astro
@@ -10,7 +10,7 @@ const parentCategory = {
   title: "Car Detailing Services"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 
 const serviceSchema = {
   "@context": "https://schema.org",

--- a/src/pages/quick-wash-fort-lauderdale.astro
+++ b/src/pages/quick-wash-fort-lauderdale.astro
@@ -11,7 +11,7 @@ const parentCategory = {
   title: "Car Detailing Services"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 
 const serviceSchema = {
   "@context": "https://schema.org",

--- a/src/pages/seat-shampooing-fort-lauderdale.astro
+++ b/src/pages/seat-shampooing-fort-lauderdale.astro
@@ -11,7 +11,7 @@ const parentCategory = {
   title: "Upholstery Cleaning Services"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/smoke-odor-removal-fort-lauderdale.astro
+++ b/src/pages/smoke-odor-removal-fort-lauderdale.astro
@@ -11,7 +11,7 @@ const parentCategory = {
   title: "Upholstery Cleaning Services"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/steam-cleaning-fort-lauderdale.astro
+++ b/src/pages/steam-cleaning-fort-lauderdale.astro
@@ -11,7 +11,7 @@ const parentCategory = {
   title: "Upholstery Cleaning Services"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/tire-dressing-fort-lauderdale.astro
+++ b/src/pages/tire-dressing-fort-lauderdale.astro
@@ -11,7 +11,7 @@ const parentCategory = {
   title: "Car Wash Services"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/trim-restoration-fort-lauderdale.astro
+++ b/src/pages/trim-restoration-fort-lauderdale.astro
@@ -11,7 +11,7 @@ const parentCategory = {
   title: "Car Wash Services"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/upholstery-cleaning-fort-lauderdale.astro
+++ b/src/pages/upholstery-cleaning-fort-lauderdale.astro
@@ -6,7 +6,7 @@ const base = import.meta.env.BASE_URL;
 const title = "Upholstery Cleaning Fort Lauderdale | Mobile Service | Route95";
 const description = "Mobile upholstery cleaning in Fort Lauderdale. Seats, carpets, leather, odor removal. We come to you with professional equipment. Same-day available. Call 754-215-2272.";
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const categorySchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/water-spot-removal-fort-lauderdale.astro
+++ b/src/pages/water-spot-removal-fort-lauderdale.astro
@@ -11,7 +11,7 @@ const parentCategory = {
   title: "Car Wash Services"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",

--- a/src/pages/wheel-cleaning-fort-lauderdale.astro
+++ b/src/pages/wheel-cleaning-fort-lauderdale.astro
@@ -11,7 +11,7 @@ const parentCategory = {
   title: "Car Wash Services"
 };
 
-const siteUrl = "https://www.route95mobilecardetailing.com";
+const siteUrl = "https://route95mobilecardetailing.com";
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",


### PR DESCRIPTION
Consolidate all URL references to use https://route95mobilecardetailing.com (non-www) as the canonical domain, matching the Google Search Console configuration. This stops link equity split across 4 URL variants.

Changes across 62 files:
- astro.config.mjs: Update site URL
- public/CNAME: Point to non-www domain for GitHub Pages
- public/robots.txt: Update sitemap URL
- BaseLayout.astro: Update siteUrl, schema @id, url, image, and OfferCatalog references
- All 58 EN/ES service and index pages: Update hardcoded siteUrl

https://claude.ai/code/session_016hCo7kz77C3YgdRFWVWr26