### PR TITLE
Add blog at /blog/ subdirectory with bilingual support

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -39,6 +39,19 @@ export default defineConfig({
           item.priority = 0.9;
           item.changefreq = 'weekly';
         }
+        // Blog index pages
+        else if (
+          item.url.match(/\/blog\/$/) ||
+          item.url.match(/\/es\/blog\/$/)
+        ) {
+          item.priority = 0.8;
+          item.changefreq = 'weekly';
+        }
+        // Blog posts
+        else if (item.url.includes('/blog/')) {
+          item.priority = 0.6;
+          item.changefreq = 'monthly';
+        }
         // About and Contact pages
         else if (
           item.url.includes('/about/') ||

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -27,6 +27,7 @@ const upholsteryUrl = localizedUrl(locale, 'upholstery-cleaning-fort-lauderdale'
 const detailingUrl = localizedUrl(locale, 'car-detailing-services-fort-lauderdale');
 const aboutUrl = localizedUrl(locale, 'about');
 const contactUrl = localizedUrl(locale, 'contact');
+const blogUrl = localizedUrl(locale, 'blog');
 ---
 
 <header class="sticky top-0 z-50 bg-white shadow-md">
@@ -140,6 +141,12 @@ const contactUrl = localizedUrl(locale, 'contact');
           </div>
         </div>
 
+        <a
+          href={blogUrl}
+          class={`text-gray-700 hover:text-[#1a3d6b] transition-colors font-medium ${currentPage.includes('/blog/') ? 'text-[#0f2a4a] border-b-2 border-[#c0c7cf]' : ''}`}
+        >
+          {t.blog.title}
+        </a>
         <a
           href={aboutUrl}
           class={`text-gray-700 hover:text-[#1a3d6b] transition-colors font-medium ${currentPage === '/about/' || currentPage === '/es/nosotros/' ? 'text-[#0f2a4a] border-b-2 border-[#c0c7cf]' : ''}`}

--- a/src/content/blog/en/how-to-protect-car-paint-south-florida-sun.md
+++ b/src/content/blog/en/how-to-protect-car-paint-south-florida-sun.md
@@ -1,0 +1,61 @@
+---
+title: "How to Protect Your Car's Paint from the South Florida Sun"
+description: "South Florida's UV rays are among the strongest in the country. Learn proven methods to protect your car's paint from sun damage, oxidation, and fading in Fort Lauderdale."
+date: 2025-07-20
+author: "Gustavo Moya"
+---
+
+Fort Lauderdale averages over 3,000 hours of sunshine per year. That's great for beach days but brutal on your car's paint. UV radiation breaks down the clear coat over time, leading to oxidation, fading, and that chalky appearance that makes any vehicle look years older than it is.
+
+The good news? With the right care routine, you can keep your paint looking fresh despite constant sun exposure.
+
+## Understanding UV Damage
+
+Your car's paint system has multiple layers: primer, base coat (the color), and clear coat (the protective layer). UV rays primarily attack the clear coat. Once that breaks down, the base coat is exposed to the elements and deteriorates rapidly.
+
+Signs of UV damage include:
+
+- **Fading**: Colors look washed out, especially reds and blacks
+- **Oxidation**: A chalky, dull appearance on the surface
+- **Peeling clear coat**: Visible flaking, especially on horizontal surfaces like the hood and roof
+- **Rough texture**: The paint feels gritty instead of smooth
+
+## Proven Protection Methods
+
+### Regular Washing
+
+Dirt, pollen, and bird droppings accelerate UV damage by creating hot spots on the paint surface. Regular washing removes these contaminants before they cause harm. Use a pH-balanced car shampoo — dish soap strips existing wax and protection.
+
+At Route95, we use Chemical Guys Mr. Pink Super Suds and Koch-Chemie nano-tech shampoos specifically because they clean without stripping protection.
+
+### Wax or Sealant Application
+
+Wax creates a sacrificial barrier between UV rays and your clear coat. It absorbs UV radiation so your paint doesn't have to. The trade-off: wax breaks down over time and needs reapplication every few months.
+
+Synthetic sealants last longer than natural wax — typically 4 to 6 months versus 6 to 8 weeks for carnauba wax. For South Florida conditions, we recommend a sealant for durability with a wax topper for depth of shine.
+
+### Clay Bar Treatment
+
+Before applying any protection, the paint surface needs to be truly clean. A clay bar removes embedded contaminants that washing alone can't touch — industrial fallout, overspray, tree sap residue, and rail dust.
+
+Running your hand over freshly clayed paint versus unwashed paint is a night-and-day difference. The surface becomes glass-smooth, which also helps wax and sealant bond more effectively.
+
+### Park Smart
+
+This seems obvious, but parking in shade whenever possible significantly reduces UV exposure. Garage parking is ideal. If that's not available, a car cover or even a windshield sun shade helps protect the most exposed surfaces.
+
+## What About Ceramic Coating?
+
+Ceramic coatings provide the longest-lasting UV protection available — typically 2 to 5 years depending on the product. They create a semi-permanent bond with your clear coat that's far more durable than wax or sealant.
+
+However, ceramic coating requires professional application and significant surface preparation. It's an investment, but for South Florida car owners who want long-term protection, it's worth considering.
+
+## A Practical Routine for Fort Lauderdale
+
+Here's a realistic maintenance schedule for protecting your paint in our climate:
+
+1. **Every 2 weeks**: Hand wash with quality car shampoo
+2. **Every 3 months**: Clay bar treatment and wax or sealant application
+3. **Immediately**: Remove bird droppings, tree sap, and bug splatter as soon as you notice them
+
+Route95 Mobile Car Detailing offers all of these services at your location in Fort Lauderdale, Dania Beach, Hollywood, and Pompano Beach. We bring everything we need — you don't even need a hose. Call 754-215-2272 for a free quote.

--- a/src/content/blog/en/interior-car-cleaning-tips-florida-humidity.md
+++ b/src/content/blog/en/interior-car-cleaning-tips-florida-humidity.md
@@ -1,0 +1,82 @@
+---
+title: "Interior Car Cleaning Tips for Florida's Humidity"
+description: "Florida's humidity creates unique challenges for your car's interior. Learn how to prevent mold, eliminate odors, and keep your seats and carpets clean in Fort Lauderdale's tropical climate."
+date: 2025-08-10
+author: "Gustavo Moya"
+---
+
+Florida humidity doesn't just make you uncomfortable — it does real damage inside your car. Moisture gets trapped in carpets, under seats, and inside ventilation systems. Left unchecked, it leads to mold growth, musty odors, and deteriorating upholstery.
+
+If you've ever noticed a stale smell when you open your car door in the morning, humidity is likely the cause. Here's how to fight back.
+
+## Why Florida Interiors Need Extra Attention
+
+The average relative humidity in Fort Lauderdale hovers around 75%. Inside a closed car sitting in the sun, conditions become a greenhouse — hot and damp. This is the exact environment where mold and mildew thrive.
+
+Common problems include:
+
+- **Musty or mildew smell** that air fresheners only mask
+- **Mold growth** under floor mats and in seat crevices
+- **Foggy windows** from interior moisture
+- **Sticky surfaces** on dashboards and consoles
+- **Leather cracking** from heat and humidity cycles
+
+## Keeping Your Interior Dry
+
+### Don't Leave Windows Cracked
+
+Many people crack their windows to "let the car breathe." In Florida, this actually invites humidity inside. Keep windows sealed when parked. If your car has a cabin air recirculation mode, use it to reduce the amount of humid outside air entering the system.
+
+### Use Your AC Before Turning Off
+
+Run your air conditioning on recirculate mode for the last few minutes of every drive. This helps dry out the evaporator and reduces the moisture available for mold growth in your ventilation system.
+
+### Check Your Cabin Air Filter
+
+A clogged cabin air filter restricts airflow and can trap moisture. Replace it every 15,000 to 20,000 miles — or more frequently in Florida's pollen-heavy environment. A fresh filter also improves air quality and AC performance.
+
+### Floor Mats Matter
+
+Rubber or all-weather floor mats are essential in Florida. They prevent moisture from soaking into your carpet. Remove and dry them regularly — water collects underneath and promotes mold growth without you realizing it.
+
+## Deep Cleaning Your Interior
+
+### Carpet and Seat Shampooing
+
+Even with regular vacuuming, Florida car carpets accumulate moisture and organic material that regular cleaning can't reach. A hot water extraction (steam cleaning) process pulls deep-seated dirt and moisture out of carpet fibers and upholstery.
+
+At Route95, we use Chemical Guys Foaming Citrus Fabric Clean and professional extractors that inject cleaning solution deep into the fabric and then vacuum it out along with the dirt.
+
+### Leather Care in Humidity
+
+Leather seats in Florida face a double threat: UV damage from the sun and moisture damage from humidity. Leather is a natural material that absorbs and releases moisture. In Florida's humid climate, this constant cycling can cause cracking and discoloration.
+
+Clean leather with a pH-balanced leather cleaner — never household cleaners or baby wipes, which can strip the finish. Follow with a quality leather conditioner that contains UV protection. Koch-Chemie and Chemical Guys both make excellent options we use daily.
+
+### Dashboard and Console Cleaning
+
+Plastic and vinyl surfaces get sticky in humidity as plasticizers break down. Use a dedicated interior cleaner, not household products like Armor All that leave greasy residues that attract more dust.
+
+A clean, lightly dressed dashboard not only looks better but resists the sticky buildup that Florida humidity causes.
+
+## Odor Elimination
+
+If your car already smells musty, air fresheners won't solve the problem. They just cover it up while mold continues to grow.
+
+Proper odor elimination requires:
+
+1. **Finding the source**: Usually under floor mats, in seat rails, or in the ventilation system
+2. **Deep cleaning**: Shampooing carpets and seats to remove mold and bacteria
+3. **Ozone treatment or enzyme cleaner**: These break down odor-causing molecules rather than masking them
+4. **Prevention**: Addressing the moisture source so the smell doesn't return
+
+## A Realistic Interior Maintenance Schedule
+
+For Fort Lauderdale car owners, here's what we recommend:
+
+- **Weekly**: Wipe down hard surfaces, check under floor mats for moisture
+- **Monthly**: Thorough vacuum including under seats and in crevices
+- **Every 3 months**: Leather cleaning and conditioning
+- **Every 6 months**: Full interior detail with carpet and seat shampooing
+
+Route95 Mobile Car Detailing handles all of this at your location. We bring our own water, power, and professional equipment to Fort Lauderdale, Dania Beach, Hollywood, and Pompano Beach. Call 754-215-2272 to schedule your interior detail.

--- a/src/content/blog/en/why-mobile-car-detailing-fort-lauderdale.md
+++ b/src/content/blog/en/why-mobile-car-detailing-fort-lauderdale.md
@@ -1,0 +1,47 @@
+---
+title: "Why Mobile Car Detailing Is the Smart Choice in Fort Lauderdale"
+description: "Discover why more Fort Lauderdale car owners are choosing mobile detailing over traditional car washes. Save time, get better results, and protect your vehicle from South Florida's harsh conditions."
+date: 2025-06-15
+author: "Gustavo Moya"
+---
+
+If you live in Fort Lauderdale, you already know what the South Florida environment does to your car. The sun beats down relentlessly, fading paint and cracking dashboards. Salt air from the Atlantic corrodes chrome and trim. And humidity creates the perfect conditions for mold and mildew inside your cabin.
+
+Most people deal with this by running through an automated car wash once a week. But those spinning brushes and recycled water actually cause more harm than good — swirl marks, scratches, and a "clean" that barely lasts two days.
+
+## What Makes Mobile Detailing Different
+
+Mobile car detailing brings a professional detailer directly to your location with all the equipment, water, and products needed to properly clean and protect your vehicle. Here's why it's a better approach:
+
+### You Don't Waste Your Saturday
+
+Instead of driving to a detail shop, waiting in line, and sitting in a lobby for hours, a mobile detailer comes to your home or office. You can work, relax, or handle errands while your car gets the attention it deserves.
+
+### Better Products, Better Results
+
+At Route95, we use professional-grade products from Chemical Guys, Koch-Chemie, and 3D. These aren't the diluted soaps and harsh chemicals used at drive-through washes. They're formulated to clean effectively while protecting your paint, leather, and trim.
+
+### One-on-One Attention
+
+Your car doesn't share a bay with dozens of other vehicles. Our detailer focuses entirely on your vehicle from start to finish. Every panel, every crevice, every surface gets proper attention.
+
+### Protection Against Florida Conditions
+
+A proper detail doesn't just clean your car — it protects it. Wax and sealant guard against UV damage. Leather conditioning prevents cracking from heat. Interior treatments fight mold and mildew growth.
+
+## The Fort Lauderdale Factor
+
+Living in Fort Lauderdale means your car faces unique challenges that generic car washes don't address:
+
+- **UV Exposure**: Our intense sunlight degrades paint, rubber, and plastic faster than almost anywhere in the country.
+- **Salt Air**: Even if you never drive on the beach, salt air reaches everywhere in Broward County.
+- **Hard Water**: Florida's mineral-rich water leaves spots and deposits that regular washing can make worse.
+- **Pollen and Tree Sap**: Our tropical vegetation means constant exposure to organic contaminants.
+
+A mobile detailer who works in Fort Lauderdale every day understands these conditions and uses products and techniques specifically suited to them.
+
+## Is Mobile Detailing Worth It?
+
+If you value your time and your vehicle, absolutely. A quality mobile detail protects your car's finish, preserves its resale value, and keeps your interior healthy — all without you having to go anywhere.
+
+Route95 Mobile Car Detailing serves Fort Lauderdale, Dania Beach, Hollywood, and Pompano Beach with same-day appointments available. Call us at 754-215-2272 to schedule your first mobile detail.

--- a/src/content/blog/es/como-proteger-pintura-auto-sol-sur-florida.md
+++ b/src/content/blog/es/como-proteger-pintura-auto-sol-sur-florida.md
@@ -1,0 +1,61 @@
+---
+title: "Cómo Proteger la Pintura de Su Auto del Sol del Sur de Florida"
+description: "Los rayos UV del sur de Florida están entre los más fuertes del país. Aprenda métodos comprobados para proteger la pintura de su auto contra el daño solar y la oxidación en Fort Lauderdale."
+date: 2025-07-20
+author: "Gustavo Moya"
+---
+
+Fort Lauderdale tiene un promedio de más de 3,000 horas de sol al año. Eso es excelente para los días de playa pero brutal para la pintura de su auto. La radiación UV descompone la capa transparente con el tiempo, lo que lleva a la oxidación, decoloración y esa apariencia opaca que hace que cualquier vehículo se vea años más viejo de lo que es.
+
+La buena noticia es que con la rutina de cuidado adecuada, puede mantener su pintura luciendo fresca a pesar de la exposición constante al sol.
+
+## Entendiendo el Daño UV
+
+El sistema de pintura de su auto tiene múltiples capas: imprimación, capa base (el color) y capa transparente (la capa protectora). Los rayos UV atacan principalmente la capa transparente. Una vez que esta se descompone, la capa base queda expuesta a los elementos y se deteriora rápidamente.
+
+Los signos de daño UV incluyen:
+
+- **Decoloración**: Los colores se ven deslavados, especialmente rojos y negros
+- **Oxidación**: Una apariencia opaca y calcárea en la superficie
+- **Descascaramiento**: Descamación visible, especialmente en superficies horizontales como el capó y el techo
+- **Textura áspera**: La pintura se siente granulosa en lugar de suave
+
+## Métodos de Protección Comprobados
+
+### Lavado Regular
+
+La suciedad, el polen y los excrementos de aves aceleran el daño UV al crear puntos calientes en la superficie de la pintura. El lavado regular elimina estos contaminantes antes de que causen daño. Use un champú para autos con pH balanceado — el jabón para platos elimina la cera y protección existentes.
+
+En Route95, usamos Chemical Guys Mr. Pink Super Suds y champús nano-tech de Koch-Chemie específicamente porque limpian sin eliminar la protección.
+
+### Aplicación de Cera o Sellador
+
+La cera crea una barrera sacrificial entre los rayos UV y su capa transparente. Absorbe la radiación UV para que su pintura no tenga que hacerlo. La desventaja: la cera se descompone con el tiempo y necesita reaplicación cada pocos meses.
+
+Los selladores sintéticos duran más que la cera natural — típicamente 4 a 6 meses versus 6 a 8 semanas para la cera de carnauba. Para las condiciones del sur de Florida, recomendamos un sellador por durabilidad con una capa de cera para profundidad de brillo.
+
+### Tratamiento con Barra de Arcilla
+
+Antes de aplicar cualquier protección, la superficie de la pintura necesita estar verdaderamente limpia. Una barra de arcilla elimina contaminantes incrustados que el lavado solo no puede alcanzar — residuos industriales, exceso de pintura, residuos de savia y polvo de frenos.
+
+Pasar la mano sobre una pintura recién tratada con arcilla versus una sin tratar es una diferencia de la noche al día. La superficie se vuelve suave como vidrio, lo que también ayuda a que la cera y el sellador se adhieran más efectivamente.
+
+### Estacione Inteligentemente
+
+Esto parece obvio, pero estacionar a la sombra siempre que sea posible reduce significativamente la exposición UV. El estacionamiento en garaje es ideal. Si eso no está disponible, una cubierta para auto o incluso un parasol para parabrisas ayuda a proteger las superficies más expuestas.
+
+## ¿Qué Hay del Recubrimiento Cerámico?
+
+Los recubrimientos cerámicos proporcionan la protección UV más duradera disponible — típicamente de 2 a 5 años dependiendo del producto. Crean un enlace semi-permanente con su capa transparente que es mucho más duradero que la cera o el sellador.
+
+Sin embargo, el recubrimiento cerámico requiere aplicación profesional y una preparación significativa de la superficie. Es una inversión, pero para los propietarios de autos en el sur de Florida que quieren protección a largo plazo, vale la pena considerarlo.
+
+## Una Rutina Práctica para Fort Lauderdale
+
+Aquí hay un calendario de mantenimiento realista para proteger su pintura en nuestro clima:
+
+1. **Cada 2 semanas**: Lavado a mano con champú de calidad
+2. **Cada 3 meses**: Tratamiento con barra de arcilla y aplicación de cera o sellador
+3. **Inmediatamente**: Elimine excrementos de aves, savia y restos de insectos tan pronto como los note
+
+Route95 Mobile Car Detailing ofrece todos estos servicios en su ubicación en Fort Lauderdale, Dania Beach, Hollywood y Pompano Beach. Traemos todo lo que necesitamos — usted ni siquiera necesita una manguera. Llame al 754-215-2272 para una cotización gratis.

--- a/src/content/blog/es/consejos-limpieza-interior-auto-humedad-florida.md
+++ b/src/content/blog/es/consejos-limpieza-interior-auto-humedad-florida.md
@@ -1,0 +1,82 @@
+---
+title: "Consejos de Limpieza Interior del Auto para la Humedad de Florida"
+description: "La humedad de Florida crea desafíos únicos para el interior de su auto. Aprenda cómo prevenir el moho, eliminar olores y mantener sus asientos y alfombras limpios en el clima tropical de Fort Lauderdale."
+date: 2025-08-10
+author: "Gustavo Moya"
+---
+
+La humedad de Florida no solo lo incomoda — causa daño real dentro de su auto. La humedad queda atrapada en las alfombras, debajo de los asientos y dentro de los sistemas de ventilación. Si no se controla, lleva al crecimiento de moho, olores desagradables y tapicería que se deteriora.
+
+Si alguna vez ha notado un olor a humedad cuando abre la puerta de su auto por la mañana, la humedad es probablemente la causa. Así es como puede combatirlo.
+
+## Por Qué los Interiores en Florida Necesitan Atención Extra
+
+La humedad relativa promedio en Fort Lauderdale ronda el 75%. Dentro de un auto cerrado expuesto al sol, las condiciones se convierten en un invernadero — caliente y húmedo. Este es exactamente el ambiente donde el moho prospera.
+
+Los problemas comunes incluyen:
+
+- **Olor a moho** que los ambientadores solo enmascaran
+- **Crecimiento de moho** debajo de las alfombrillas y en las grietas de los asientos
+- **Ventanas empañadas** por la humedad interior
+- **Superficies pegajosas** en tableros y consolas
+- **Cuero agrietado** por los ciclos de calor y humedad
+
+## Manteniendo Su Interior Seco
+
+### No Deje las Ventanas Entreabiertas
+
+Muchas personas dejan las ventanas entreabiertas para que el auto "respire". En Florida, esto en realidad invita a la humedad adentro. Mantenga las ventanas cerradas cuando esté estacionado. Si su auto tiene un modo de recirculación de aire, úselo para reducir la cantidad de aire húmedo exterior que entra al sistema.
+
+### Use el AC Antes de Apagar
+
+Encienda el aire acondicionado en modo de recirculación durante los últimos minutos de cada viaje. Esto ayuda a secar el evaporador y reduce la humedad disponible para el crecimiento de moho en su sistema de ventilación.
+
+### Revise el Filtro de Aire de Cabina
+
+Un filtro de aire de cabina obstruido restringe el flujo de aire y puede atrapar humedad. Reemplácelo cada 15,000 a 20,000 millas — o más frecuentemente en el ambiente cargado de polen de Florida. Un filtro fresco también mejora la calidad del aire y el rendimiento del AC.
+
+### Las Alfombrillas Importan
+
+Las alfombrillas de goma o para todo clima son esenciales en Florida. Evitan que la humedad se filtre en su alfombra. Retírelas y séquelas regularmente — el agua se acumula debajo y promueve el crecimiento de moho sin que usted se dé cuenta.
+
+## Limpieza Profunda de Su Interior
+
+### Lavado de Alfombras y Asientos
+
+Incluso con aspirado regular, las alfombras de autos en Florida acumulan humedad y material orgánico que la limpieza regular no puede alcanzar. Un proceso de extracción con agua caliente (limpieza a vapor) extrae la suciedad profunda y la humedad de las fibras de la alfombra y la tapicería.
+
+En Route95, usamos Chemical Guys Foaming Citrus Fabric Clean y extractores profesionales que inyectan solución limpiadora profundamente en la tela y luego la aspiran junto con la suciedad.
+
+### Cuidado del Cuero en la Humedad
+
+Los asientos de cuero en Florida enfrentan una doble amenaza: daño UV del sol y daño por humedad. El cuero es un material natural que absorbe y libera humedad. En el clima húmedo de Florida, este ciclo constante puede causar agrietamiento y decoloración.
+
+Limpie el cuero con un limpiador de cuero con pH balanceado — nunca use productos de limpieza del hogar o toallitas para bebé, que pueden eliminar el acabado. Siga con un acondicionador de cuero de calidad que contenga protección UV. Koch-Chemie y Chemical Guys tienen excelentes opciones que usamos a diario.
+
+### Limpieza de Tablero y Consola
+
+Las superficies de plástico y vinilo se vuelven pegajosas con la humedad a medida que los plastificantes se descomponen. Use un limpiador interior dedicado, no productos domésticos como Armor All que dejan residuos grasosos que atraen más polvo.
+
+Un tablero limpio y ligeramente tratado no solo se ve mejor, sino que resiste la acumulación pegajosa que la humedad de Florida causa.
+
+## Eliminación de Olores
+
+Si su auto ya huele a humedad, los ambientadores no resolverán el problema. Solo lo cubren mientras el moho sigue creciendo.
+
+La eliminación adecuada de olores requiere:
+
+1. **Encontrar la fuente**: Generalmente debajo de las alfombrillas, en los rieles de los asientos o en el sistema de ventilación
+2. **Limpieza profunda**: Lavado de alfombras y asientos para eliminar moho y bacterias
+3. **Tratamiento con ozono o limpiador enzimático**: Estos descomponen las moléculas que causan el olor en lugar de enmascararlas
+4. **Prevención**: Abordar la fuente de humedad para que el olor no regrese
+
+## Un Calendario Realista de Mantenimiento Interior
+
+Para los propietarios de autos en Fort Lauderdale, esto es lo que recomendamos:
+
+- **Semanalmente**: Limpie superficies duras, revise debajo de las alfombrillas por humedad
+- **Mensualmente**: Aspirado completo incluyendo debajo de los asientos y en las grietas
+- **Cada 3 meses**: Limpieza y acondicionamiento de cuero
+- **Cada 6 meses**: Detallado interior completo con lavado de alfombras y asientos
+
+Route95 Mobile Car Detailing se encarga de todo esto en su ubicación. Traemos nuestra propia agua, energía y equipo profesional a Fort Lauderdale, Dania Beach, Hollywood y Pompano Beach. Llame al 754-215-2272 para programar su detallado interior.

--- a/src/content/blog/es/por-que-detallado-movil-fort-lauderdale.md
+++ b/src/content/blog/es/por-que-detallado-movil-fort-lauderdale.md
@@ -1,0 +1,47 @@
+---
+title: "Por Qué el Detallado Móvil Es la Mejor Opción en Fort Lauderdale"
+description: "Descubra por qué más propietarios de autos en Fort Lauderdale eligen el detallado móvil en lugar de los lavados tradicionales. Ahorre tiempo, obtenga mejores resultados y proteja su vehículo."
+date: 2025-06-15
+author: "Gustavo Moya"
+---
+
+Si vive en Fort Lauderdale, ya sabe lo que el ambiente del sur de Florida le hace a su auto. El sol golpea sin descanso, decolorando la pintura y agrietando los tableros. El aire salado del Atlántico corroe el cromo y las molduras. Y la humedad crea las condiciones perfectas para el moho dentro de la cabina.
+
+La mayoría de las personas lidian con esto pasando por un lavado automático una vez a la semana. Pero esos cepillos giratorios y el agua reciclada en realidad causan más daño que beneficio — marcas circulares, rayones y una "limpieza" que apenas dura dos días.
+
+## Qué Hace Diferente al Detallado Móvil
+
+El detallado móvil de autos trae a un profesional directamente a su ubicación con todo el equipo, agua y productos necesarios para limpiar y proteger adecuadamente su vehículo. He aquí por qué es un mejor enfoque:
+
+### No Pierde Su Sábado
+
+En lugar de manejar a un taller, esperar en fila y sentarse en una sala de espera por horas, un detallador móvil llega a su casa u oficina. Puede trabajar, descansar o hacer sus diligencias mientras su auto recibe la atención que merece.
+
+### Mejores Productos, Mejores Resultados
+
+En Route95, usamos productos profesionales de Chemical Guys, Koch-Chemie y 3D. Estos no son los jabones diluidos y químicos agresivos que usan en los lavados automáticos. Están formulados para limpiar eficazmente mientras protegen su pintura, cuero y molduras.
+
+### Atención Personalizada
+
+Su auto no comparte un espacio con docenas de otros vehículos. Nuestro detallador se enfoca completamente en su vehículo de principio a fin. Cada panel, cada grieta, cada superficie recibe la atención adecuada.
+
+### Protección Contra las Condiciones de Florida
+
+Un detallado adecuado no solo limpia su auto — lo protege. La cera y el sellador protegen contra el daño UV. El acondicionamiento del cuero previene el agrietamiento por el calor. Los tratamientos interiores combaten el crecimiento de moho.
+
+## El Factor Fort Lauderdale
+
+Vivir en Fort Lauderdale significa que su auto enfrenta desafíos únicos que los lavados genéricos no abordan:
+
+- **Exposición UV**: Nuestra intensa luz solar degrada la pintura, el caucho y el plástico más rápido que casi cualquier otro lugar del país.
+- **Aire Salado**: Incluso si nunca maneja a la playa, el aire salado llega a todas partes del condado de Broward.
+- **Agua Dura**: El agua rica en minerales de Florida deja manchas y depósitos que el lavado regular puede empeorar.
+- **Polen y Savia**: Nuestra vegetación tropical significa exposición constante a contaminantes orgánicos.
+
+Un detallador móvil que trabaja en Fort Lauderdale todos los días entiende estas condiciones y usa productos y técnicas específicamente adecuados para ellas.
+
+## ¿Vale la Pena el Detallado Móvil?
+
+Si valora su tiempo y su vehículo, absolutamente. Un detallado móvil de calidad protege el acabado de su auto, preserva su valor de reventa y mantiene su interior saludable — todo sin que tenga que ir a ningún lado.
+
+Route95 Mobile Car Detailing sirve a Fort Lauderdale, Dania Beach, Hollywood y Pompano Beach con citas disponibles el mismo día. Llámenos al 754-215-2272 para programar su primer detallado móvil.

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -1,0 +1,13 @@
+import { defineCollection, z } from 'astro:content';
+
+const blog = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string(),
+    description: z.string(),
+    date: z.date(),
+    author: z.string().default('Route95 Mobile Car Detailing'),
+  }),
+});
+
+export const collections = { blog };

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -70,6 +70,11 @@
     "message": "Hi! I'd like to get a quote for mobile car detailing.",
     "ariaLabel": "Chat on WhatsApp"
   },
+  "blog": {
+    "title": "Blog",
+    "backToBlog": "Back to Blog",
+    "readMore": "Read More"
+  },
   "nav": {
     "handWash": "Hand Wash",
     "carWaxing": "Car Waxing",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -70,6 +70,11 @@
     "message": "¡Hola! Me gustaría obtener una cotización para detallado de auto a domicilio.",
     "ariaLabel": "Chatear por WhatsApp"
   },
+  "blog": {
+    "title": "Blog",
+    "backToBlog": "Volver al Blog",
+    "readMore": "Leer Más"
+  },
   "nav": {
     "handWash": "Lavado a Mano",
     "carWaxing": "Encerado de Autos",

--- a/src/i18n/slugs.ts
+++ b/src/i18n/slugs.ts
@@ -33,6 +33,7 @@ export const slugMap: Record<string, string> = {
   'premium-refresh-fort-lauderdale': 'renovacion-premium-fort-lauderdale',
   'fabric-protection-fort-lauderdale': 'proteccion-de-tela-fort-lauderdale',
   'interior-protection-fort-lauderdale': 'proteccion-interior-fort-lauderdale',
+  'blog': 'blog',
 };
 
 // Reverse map: Spanish slug -> English slug

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -89,6 +89,7 @@ export function getLocalizedNavLinks(locale: Locale) {
       { href: url('car-wash-fort-lauderdale'), label: t.header.carWash },
       { href: url('upholstery-cleaning-fort-lauderdale'), label: t.header.upholsteryCleaning },
       { href: url('car-detailing-services-fort-lauderdale'), label: t.header.detailingServices },
+      { href: url('blog'), label: t.blog.title },
       { href: url('about'), label: t.header.about },
       { href: url('contact'), label: t.header.contact },
     ],

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -1,0 +1,101 @@
+---
+import BaseLayout from './BaseLayout.astro';
+import { getTranslations, localizedUrl, type Locale } from '../i18n/utils';
+
+interface Props {
+  title: string;
+  description: string;
+  date: Date;
+  author: string;
+}
+
+const { title, description, date, author } = Astro.props;
+const locale = (Astro.currentLocale ?? 'en') as Locale;
+const t = getTranslations(locale);
+const blogUrl = locale === 'es' ? '/es/blog/' : '/blog/';
+const contactUrl = localizedUrl(locale, 'contact');
+
+const formattedDate = date.toLocaleDateString(locale === 'es' ? 'es-US' : 'en-US', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+});
+
+const articleSchema = {
+  "@context": "https://schema.org",
+  "@type": "BlogPosting",
+  "headline": title,
+  "description": description,
+  "datePublished": date.toISOString(),
+  "author": {
+    "@type": "Person",
+    "name": author,
+  },
+  "publisher": {
+    "@id": "https://route95mobilecardetailing.com/#organization",
+  },
+  "mainEntityOfPage": {
+    "@type": "WebPage",
+    "@id": Astro.url.href,
+  },
+};
+---
+
+<BaseLayout title={`${title} | Route95 Blog`} description={description} currentPage="/blog/" schema={articleSchema}>
+  <!-- Hero Section -->
+  <section class="bg-gradient-to-br from-[#0c2448] to-[#1a5ca0] text-white py-16 lg:py-20">
+    <div class="max-w-4xl mx-auto px-4">
+      <a href={blogUrl} class="inline-flex items-center gap-2 text-gray-200 hover:text-[#c0c7cf] mb-4 transition-colors">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+        </svg>
+        {t.blog.backToBlog}
+      </a>
+      <h1 class="text-3xl lg:text-4xl xl:text-5xl font-bold mb-6">{title}</h1>
+      <div class="flex items-center gap-4 text-gray-200">
+        <span>{author}</span>
+        <span>·</span>
+        <time datetime={date.toISOString()}>{formattedDate}</time>
+      </div>
+    </div>
+  </section>
+
+  <!-- Article Content -->
+  <article class="py-12 lg:py-16">
+    <div class="max-w-4xl mx-auto px-4">
+      <div class="prose prose-lg max-w-none
+        [&_h2]:font-[Oswald,sans-serif] [&_h2]:text-[#0f2a4a] [&_h2]:text-2xl [&_h2]:lg:text-3xl [&_h2]:font-bold [&_h2]:mt-10 [&_h2]:mb-4 [&_h2]:uppercase [&_h2]:tracking-wide
+        [&_h3]:font-[Oswald,sans-serif] [&_h3]:text-[#0f2a4a] [&_h3]:text-xl [&_h3]:lg:text-2xl [&_h3]:font-bold [&_h3]:mt-8 [&_h3]:mb-3 [&_h3]:uppercase [&_h3]:tracking-wide
+        [&_p]:text-gray-600 [&_p]:mb-4 [&_p]:leading-relaxed
+        [&_ul]:space-y-2 [&_ul]:mb-6 [&_ul]:pl-0
+        [&_ol]:space-y-2 [&_ol]:mb-6
+        [&_li]:text-gray-600
+        [&_strong]:text-[#0f2a4a]
+        [&_a]:text-[#1a3d6b] [&_a]:underline [&_a]:hover:text-[#0f2a4a]
+      ">
+        <slot />
+      </div>
+    </div>
+  </article>
+
+  <!-- CTA Section -->
+  <section class="py-12 lg:py-16 bg-gradient-to-br from-[#0c2448] to-[#1a5ca0] text-white">
+    <div class="max-w-4xl mx-auto px-4 text-center">
+      <h2 class="text-3xl font-bold mb-4">{t.serviceLayout.readyToGetStarted}</h2>
+      <p class="text-xl text-gray-200 mb-8">
+        {t.serviceLayout.ctaDescription}
+      </p>
+      <div class="flex flex-col sm:flex-row gap-4 justify-center">
+        <a href="tel:+17542152272" class="btn-accent text-lg flex items-center justify-center gap-2">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
+          </svg>
+          {t.serviceLayout.call}
+        </a>
+        <a href={contactUrl} class="bg-white text-[#0f2a4a] px-6 py-3 rounded-md font-semibold hover:bg-gray-100 transition-colors">
+          {t.serviceLayout.requestAQuote}
+        </a>
+      </div>
+    </div>
+  </section>
+</BaseLayout>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -1,0 +1,26 @@
+---
+import { getCollection } from 'astro:content';
+import BlogLayout from '../../layouts/BlogLayout.astro';
+
+export async function getStaticPaths() {
+  const allPosts = await getCollection('blog');
+  const enPosts = allPosts.filter(post => post.id.startsWith('en/'));
+
+  return enPosts.map(post => ({
+    params: { slug: post.id.replace('en/', '').replace(/\.md$/, '') },
+    props: { post },
+  }));
+}
+
+const { post } = Astro.props;
+const { Content } = await post.render();
+---
+
+<BlogLayout
+  title={post.data.title}
+  description={post.data.description}
+  date={post.data.date}
+  author={post.data.author}
+>
+  <Content />
+</BlogLayout>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,0 +1,89 @@
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+const allPosts = await getCollection('blog');
+const enPosts = allPosts
+  .filter(post => post.id.startsWith('en/'))
+  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
+
+const title = "Car Detailing Blog | Route95 Mobile Car Detailing";
+const description = "Expert car care tips, detailing guides, and advice for Fort Lauderdale car owners. Learn how to protect your vehicle from South Florida's sun, salt, and humidity.";
+
+const blogSchema = {
+  "@context": "https://schema.org",
+  "@type": "Blog",
+  "name": "Route95 Mobile Car Detailing Blog",
+  "description": description,
+  "url": "https://route95mobilecardetailing.com/blog/",
+  "publisher": {
+    "@id": "https://route95mobilecardetailing.com/#organization",
+  },
+};
+---
+
+<BaseLayout title={title} description={description} currentPage="/blog/" schema={blogSchema}>
+  <!-- Hero Section -->
+  <section class="bg-gradient-to-br from-[#0c2448] to-[#1a5ca0] text-white py-16 lg:py-20">
+    <div class="max-w-7xl mx-auto px-4">
+      <h1 class="text-4xl lg:text-5xl font-bold mb-6">Car Detailing Blog</h1>
+      <p class="text-xl text-gray-200 max-w-3xl">
+        Expert tips and guides to help you keep your car looking its best in Fort Lauderdale's tough climate. From paint protection to interior care, we cover it all.
+      </p>
+    </div>
+  </section>
+
+  <!-- Blog Posts Grid -->
+  <section class="py-16 lg:py-24">
+    <div class="max-w-7xl mx-auto px-4">
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+        {enPosts.map(post => {
+          const slug = post.id.replace('en/', '').replace(/\.md$/, '');
+          return (
+            <a href={`/blog/${slug}/`} class="service-card bg-white rounded-xl shadow-lg overflow-hidden group">
+              <div class="h-3 bg-gradient-to-r from-[#0c2448] to-[#1a5ca0]"></div>
+              <div class="p-6">
+                <time datetime={post.data.date.toISOString()} class="text-sm text-gray-500">
+                  {post.data.date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}
+                </time>
+                <h2 class="text-xl font-bold text-[#0f2a4a] mt-2 mb-3 group-hover:text-[#1a3d6b] transition-colors">
+                  {post.data.title}
+                </h2>
+                <p class="text-gray-600 mb-4 line-clamp-3">{post.data.description}</p>
+                <span class="inline-flex items-center text-[#0f2a4a] font-semibold group-hover:text-[#1a3d6b] transition-colors">
+                  Read More
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 ml-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
+                  </svg>
+                </span>
+              </div>
+            </a>
+          );
+        })}
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA Section -->
+  <section class="py-16 lg:py-24 bg-gradient-to-br from-[#0c2448] to-[#1a5ca0] text-white">
+    <div class="max-w-4xl mx-auto px-4 text-center">
+      <h2 class="text-3xl lg:text-4xl font-bold mb-6">
+        Ready to Give Your Car the Care It Deserves?
+      </h2>
+      <p class="text-xl text-gray-200 mb-8">
+        Call us today for same-day mobile service throughout Fort Lauderdale, Dania Beach, Hollywood, and Pompano Beach.
+      </p>
+      <div class="flex flex-col sm:flex-row gap-4 justify-center">
+        <a href="tel:+17542152272" class="btn-accent text-lg flex items-center justify-center gap-2">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
+          </svg>
+          Call 754-215-2272
+        </a>
+        <a href="/contact/" class="bg-white text-[#0f2a4a] px-6 py-3 rounded-md font-semibold hover:bg-gray-100 transition-colors">
+          Request a Quote
+        </a>
+      </div>
+    </div>
+  </section>
+</BaseLayout>

--- a/src/pages/es/blog/[slug].astro
+++ b/src/pages/es/blog/[slug].astro
@@ -1,0 +1,26 @@
+---
+import { getCollection } from 'astro:content';
+import BlogLayout from '../../../layouts/BlogLayout.astro';
+
+export async function getStaticPaths() {
+  const allPosts = await getCollection('blog');
+  const esPosts = allPosts.filter(post => post.id.startsWith('es/'));
+
+  return esPosts.map(post => ({
+    params: { slug: post.id.replace('es/', '').replace(/\.md$/, '') },
+    props: { post },
+  }));
+}
+
+const { post } = Astro.props;
+const { Content } = await post.render();
+---
+
+<BlogLayout
+  title={post.data.title}
+  description={post.data.description}
+  date={post.data.date}
+  author={post.data.author}
+>
+  <Content />
+</BlogLayout>

--- a/src/pages/es/blog/index.astro
+++ b/src/pages/es/blog/index.astro
@@ -1,0 +1,89 @@
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../../layouts/BaseLayout.astro';
+
+const allPosts = await getCollection('blog');
+const esPosts = allPosts
+  .filter(post => post.id.startsWith('es/'))
+  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
+
+const title = "Blog de Detallado de Autos | Route95 Mobile Car Detailing";
+const description = "Consejos expertos de cuidado automotriz, guías de detallado y asesoría para propietarios de autos en Fort Lauderdale. Aprenda cómo proteger su vehículo del sol, la sal y la humedad del sur de Florida.";
+
+const blogSchema = {
+  "@context": "https://schema.org",
+  "@type": "Blog",
+  "name": "Blog de Route95 Mobile Car Detailing",
+  "description": description,
+  "url": "https://route95mobilecardetailing.com/es/blog/",
+  "publisher": {
+    "@id": "https://route95mobilecardetailing.com/#organization",
+  },
+};
+---
+
+<BaseLayout title={title} description={description} currentPage="/es/blog/" schema={blogSchema}>
+  <!-- Hero Section -->
+  <section class="bg-gradient-to-br from-[#0c2448] to-[#1a5ca0] text-white py-16 lg:py-20">
+    <div class="max-w-7xl mx-auto px-4">
+      <h1 class="text-4xl lg:text-5xl font-bold mb-6">Blog de Detallado de Autos</h1>
+      <p class="text-xl text-gray-200 max-w-3xl">
+        Consejos y guías de expertos para ayudarle a mantener su auto luciendo lo mejor posible en el difícil clima de Fort Lauderdale. Desde protección de pintura hasta cuidado interior, lo cubrimos todo.
+      </p>
+    </div>
+  </section>
+
+  <!-- Blog Posts Grid -->
+  <section class="py-16 lg:py-24">
+    <div class="max-w-7xl mx-auto px-4">
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+        {esPosts.map(post => {
+          const slug = post.id.replace('es/', '').replace(/\.md$/, '');
+          return (
+            <a href={`/es/blog/${slug}/`} class="service-card bg-white rounded-xl shadow-lg overflow-hidden group">
+              <div class="h-3 bg-gradient-to-r from-[#0c2448] to-[#1a5ca0]"></div>
+              <div class="p-6">
+                <time datetime={post.data.date.toISOString()} class="text-sm text-gray-500">
+                  {post.data.date.toLocaleDateString('es-US', { year: 'numeric', month: 'long', day: 'numeric' })}
+                </time>
+                <h2 class="text-xl font-bold text-[#0f2a4a] mt-2 mb-3 group-hover:text-[#1a3d6b] transition-colors">
+                  {post.data.title}
+                </h2>
+                <p class="text-gray-600 mb-4 line-clamp-3">{post.data.description}</p>
+                <span class="inline-flex items-center text-[#0f2a4a] font-semibold group-hover:text-[#1a3d6b] transition-colors">
+                  Leer Más
+                  <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5 ml-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 8l4 4m0 0l-4 4m4-4H3" />
+                  </svg>
+                </span>
+              </div>
+            </a>
+          );
+        })}
+      </div>
+    </div>
+  </section>
+
+  <!-- CTA Section -->
+  <section class="py-16 lg:py-24 bg-gradient-to-br from-[#0c2448] to-[#1a5ca0] text-white">
+    <div class="max-w-4xl mx-auto px-4 text-center">
+      <h2 class="text-3xl lg:text-4xl font-bold mb-6">
+        ¿Listo para Darle a Su Auto el Cuidado que Merece?
+      </h2>
+      <p class="text-xl text-gray-200 mb-8">
+        Llámenos hoy para servicio móvil el mismo día en Fort Lauderdale, Dania Beach, Hollywood y Pompano Beach.
+      </p>
+      <div class="flex flex-col sm:flex-row gap-4 justify-center">
+        <a href="tel:+17542152272" class="btn-accent text-lg flex items-center justify-center gap-2">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
+          </svg>
+          Llamar 754-215-2272
+        </a>
+        <a href="/es/contacto/" class="bg-white text-[#0f2a4a] px-6 py-3 rounded-md font-semibold hover:bg-gray-100 transition-colors">
+          Solicitar Cotización
+        </a>
+      </div>
+    </div>
+  </section>
+</BaseLayout>


### PR DESCRIPTION
- Set up Astro content collections for blog posts (src/content/blog/)
- Create 3 starter blog posts in English and Spanish covering mobile detailing benefits, paint protection, and interior care in Florida
- Add BlogLayout with article schema.org markup and styled prose
- Add blog index pages at /blog/ (EN) and /es/blog/ (ES) with card grid
- Add dynamic [slug] pages for individual blog posts in both languages
- Add "Blog" link to desktop and mobile navigation in Header
- Update i18n translations (en.json, es.json) with blog strings
- Add blog slug mapping in slugs.ts
- Update sitemap config with blog index (priority 0.8) and post (priority 0.6) rules

https://claude.ai/code/session_01DixMpAEqcm3neXWcZxLGBL