### PR TITLE
Use 2x2 grid layout for quarterly detailing schedule

### DIFF
--- a/src/content/blog/en/how-often-detail-car-florida.md
+++ b/src/content/blog/en/how-often-detail-car-florida.md
@@ -208,10 +208,24 @@ Quarterly detailing prevents far more expensive corrections and preserves vehicl
 
 Here's a practical quarterly schedule:
 
-**Q1 (Jan-Mar):** Complete detail after winter (dry season, less harsh)
-**Q2 (Apr-Jun):** Complete detail before peak summer heat
-**Q3 (Jul-Sep):** Complete detail mid-summer (peak UV damage period)
-**Q4 (Oct-Dec):** Complete detail after rainy season
+<div class="grid grid-cols-2 gap-4 not-prose my-6">
+  <div class="bg-gray-50 p-4 rounded-lg">
+    <h4 class="font-semibold text-[#0f2a4a] font-[Oswald,sans-serif] uppercase tracking-wide">Q1 (Jan-Mar)</h4>
+    <p class="text-sm text-gray-600">Complete detail after winter (dry season, less harsh)</p>
+  </div>
+  <div class="bg-gray-50 p-4 rounded-lg">
+    <h4 class="font-semibold text-[#0f2a4a] font-[Oswald,sans-serif] uppercase tracking-wide">Q2 (Apr-Jun)</h4>
+    <p class="text-sm text-gray-600">Complete detail before peak summer heat</p>
+  </div>
+  <div class="bg-gray-50 p-4 rounded-lg">
+    <h4 class="font-semibold text-[#0f2a4a] font-[Oswald,sans-serif] uppercase tracking-wide">Q3 (Jul-Sep)</h4>
+    <p class="text-sm text-gray-600">Complete detail mid-summer (peak UV damage period)</p>
+  </div>
+  <div class="bg-gray-50 p-4 rounded-lg">
+    <h4 class="font-semibold text-[#0f2a4a] font-[Oswald,sans-serif] uppercase tracking-wide">Q4 (Oct-Dec)</h4>
+    <p class="text-sm text-gray-600">Complete detail after rainy season</p>
+  </div>
+</div>
 
 Between each quarterly detail, maintain with:
 - Bi-weekly maintenance washes

--- a/src/content/blog/es/cada-cuanto-detallar-auto-florida.md
+++ b/src/content/blog/es/cada-cuanto-detallar-auto-florida.md
@@ -208,10 +208,24 @@ El detallado trimestral previene correcciones mucho más costosas y preserva el 
 
 Aquí hay un calendario trimestral práctico:
 
-**T1 (Ene-Mar):** Detallado completo después del invierno (temporada seca, menos agresiva)
-**T2 (Abr-Jun):** Detallado completo antes del pico de calor veraniego
-**T3 (Jul-Sep):** Detallado completo a mitad de verano (período de máximo daño UV)
-**T4 (Oct-Dic):** Detallado completo después de la temporada de lluvias
+<div class="grid grid-cols-2 gap-4 not-prose my-6">
+  <div class="bg-gray-50 p-4 rounded-lg">
+    <h4 class="font-semibold text-[#0f2a4a] font-[Oswald,sans-serif] uppercase tracking-wide">T1 (Ene-Mar)</h4>
+    <p class="text-sm text-gray-600">Detallado completo después del invierno (temporada seca, menos agresiva)</p>
+  </div>
+  <div class="bg-gray-50 p-4 rounded-lg">
+    <h4 class="font-semibold text-[#0f2a4a] font-[Oswald,sans-serif] uppercase tracking-wide">T2 (Abr-Jun)</h4>
+    <p class="text-sm text-gray-600">Detallado completo antes del pico de calor veraniego</p>
+  </div>
+  <div class="bg-gray-50 p-4 rounded-lg">
+    <h4 class="font-semibold text-[#0f2a4a] font-[Oswald,sans-serif] uppercase tracking-wide">T3 (Jul-Sep)</h4>
+    <p class="text-sm text-gray-600">Detallado completo a mitad de verano (período de máximo daño UV)</p>
+  </div>
+  <div class="bg-gray-50 p-4 rounded-lg">
+    <h4 class="font-semibold text-[#0f2a4a] font-[Oswald,sans-serif] uppercase tracking-wide">T4 (Oct-Dic)</h4>
+    <p class="text-sm text-gray-600">Detallado completo después de la temporada de lluvias</p>
+  </div>
+</div>
 
 Entre cada detallado trimestral, mantenga con:
 - Lavados de mantenimiento cada dos semanas


### PR DESCRIPTION
Replace plain text Q1-Q4 schedule with a styled 2x2 grid matching the service areas pattern from the about page, in both EN and ES versions of the detailing frequency blog post.

https://claude.ai/code/session_01DixMpAEqcm3neXWcZxLGBL