### PR TITLE
Replace detailing schedule by service type with styled table

### DIFF
--- a/src/content/blog/en/how-often-detail-car-florida.md
+++ b/src/content/blog/en/how-often-detail-car-florida.md
@@ -46,40 +46,44 @@ Florida presents a perfect storm of conditions that damage vehicles:
 
 Not every service needs the same frequency. Here's the optimal schedule for Florida vehicles:
 
-### Full Interior Detail: Every 3-4 Months
-
-Florida's humidity makes interior detailing critical. A full interior detail every quarter prevents:
-- Mold and mildew buildup in carpets and seats
-- Permanent staining from sweat and humidity
-- Odor penetration into upholstery
-- UV damage to dashboard and trim pieces
-
-### Full Exterior Detail: Every 3-4 Months
-
-Quarterly exterior details protect against:
-- Paint oxidation from UV exposure
-- Salt air corrosion on coastal vehicles
-- Water spot etching from hard water and rain
-- Contaminant bonding (tar, bugs, tree sap)
-
-### Complete Detail (Interior + Exterior): Every 3-4 Months
-
-For maximum protection, complete details every 3-4 months provide comprehensive care for Florida conditions.
-
-### Maintenance Washes: Every 2 Weeks
-
-Between full details, maintenance washes every 2 weeks remove:
-- Salt accumulation from coastal air
-- Pollen and organic debris
-- Bird droppings and bug splatter
-- Surface contaminants before they bond to paint
-
-### Ceramic Coating Maintenance: Every 6 Months
-
-If your vehicle has ceramic coating, you can extend full details to every 6 months, but still need:
-- Maintenance washes every 2 weeks
-- Coating inspection and top-up every 6 months
-- Full decontamination annually
+<div class="not-prose my-8 overflow-x-auto">
+  <table class="w-full border-collapse rounded-xl overflow-hidden shadow-lg text-sm">
+    <thead>
+      <tr class="bg-[#0f2a4a] text-white">
+        <th class="px-5 py-4 text-left font-[Oswald,sans-serif] uppercase tracking-wide font-semibold">Service Type</th>
+        <th class="px-5 py-4 text-left font-[Oswald,sans-serif] uppercase tracking-wide font-semibold">Frequency</th>
+        <th class="px-5 py-4 text-left font-[Oswald,sans-serif] uppercase tracking-wide font-semibold">Key Benefits</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr class="border-b border-gray-200 bg-white">
+        <td class="px-5 py-4 font-semibold text-[#0f2a4a]">Full Interior Detail</td>
+        <td class="px-5 py-4 text-gray-700">Every 3-4 months</td>
+        <td class="px-5 py-4 text-gray-600">Prevents mold, stains, odors, and UV damage to dashboard and trim</td>
+      </tr>
+      <tr class="border-b border-gray-200 bg-gray-50">
+        <td class="px-5 py-4 font-semibold text-[#0f2a4a]">Full Exterior Detail</td>
+        <td class="px-5 py-4 text-gray-700">Every 3-4 months</td>
+        <td class="px-5 py-4 text-gray-600">Protects against paint oxidation, salt corrosion, water spots, and contaminant bonding</td>
+      </tr>
+      <tr class="border-b border-gray-200 bg-white">
+        <td class="px-5 py-4 font-semibold text-[#0f2a4a]">Complete Detail</td>
+        <td class="px-5 py-4 text-gray-700">Every 3-4 months</td>
+        <td class="px-5 py-4 text-gray-600">Comprehensive interior + exterior care for maximum Florida climate protection</td>
+      </tr>
+      <tr class="border-b border-gray-200 bg-gray-50">
+        <td class="px-5 py-4 font-semibold text-[#0f2a4a]">Maintenance Wash</td>
+        <td class="px-5 py-4 text-gray-700">Every 2 weeks</td>
+        <td class="px-5 py-4 text-gray-600">Removes salt, pollen, bird droppings, and surface contaminants between details</td>
+      </tr>
+      <tr class="bg-white">
+        <td class="px-5 py-4 font-semibold text-[#0f2a4a]">Ceramic Coating Maintenance</td>
+        <td class="px-5 py-4 text-gray-700">Every 6 months</td>
+        <td class="px-5 py-4 text-gray-600">Coating inspection, top-up, and full decontamination (bi-weekly washes still needed)</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
 ## Detailing Frequency by Vehicle Usage
 

--- a/src/content/blog/es/cada-cuanto-detallar-auto-florida.md
+++ b/src/content/blog/es/cada-cuanto-detallar-auto-florida.md
@@ -46,40 +46,44 @@ Florida presenta una combinación perfecta de condiciones que dañan los vehícu
 
 No todos los servicios necesitan la misma frecuencia. Aquí está el calendario óptimo para vehículos en Florida:
 
-### Detallado Interior Completo: Cada 3-4 Meses
-
-La humedad de Florida hace que el detallado interior sea crítico. Un detallado interior completo cada trimestre previene:
-- Acumulación de moho en alfombras y asientos
-- Manchas permanentes por sudor y humedad
-- Penetración de olores en la tapicería
-- Daño UV al tablero y piezas de moldura
-
-### Detallado Exterior Completo: Cada 3-4 Meses
-
-Los detallados exteriores trimestrales protegen contra:
-- Oxidación de la pintura por exposición UV
-- Corrosión por aire salado en vehículos costeros
-- Grabado de manchas de agua por agua dura y lluvia
-- Adhesión de contaminantes (alquitrán, insectos, savia)
-
-### Detallado Completo (Interior + Exterior): Cada 3-4 Meses
-
-Para máxima protección, los detallados completos cada 3-4 meses proporcionan cuidado integral para las condiciones de Florida.
-
-### Lavados de Mantenimiento: Cada 2 Semanas
-
-Entre detallados completos, los lavados de mantenimiento cada 2 semanas eliminan:
-- Acumulación de sal del aire costero
-- Polen y residuos orgánicos
-- Excrementos de aves y restos de insectos
-- Contaminantes superficiales antes de que se adhieran a la pintura
-
-### Mantenimiento de Recubrimiento Cerámico: Cada 6 Meses
-
-Si su vehículo tiene recubrimiento cerámico, puede extender los detallados completos a cada 6 meses, pero aún necesita:
-- Lavados de mantenimiento cada 2 semanas
-- Inspección y retoque del recubrimiento cada 6 meses
-- Descontaminación completa anualmente
+<div class="not-prose my-8 overflow-x-auto">
+  <table class="w-full border-collapse rounded-xl overflow-hidden shadow-lg text-sm">
+    <thead>
+      <tr class="bg-[#0f2a4a] text-white">
+        <th class="px-5 py-4 text-left font-[Oswald,sans-serif] uppercase tracking-wide font-semibold">Tipo de Servicio</th>
+        <th class="px-5 py-4 text-left font-[Oswald,sans-serif] uppercase tracking-wide font-semibold">Frecuencia</th>
+        <th class="px-5 py-4 text-left font-[Oswald,sans-serif] uppercase tracking-wide font-semibold">Beneficios Clave</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr class="border-b border-gray-200 bg-white">
+        <td class="px-5 py-4 font-semibold text-[#0f2a4a]">Detallado Interior Completo</td>
+        <td class="px-5 py-4 text-gray-700">Cada 3-4 meses</td>
+        <td class="px-5 py-4 text-gray-600">Previene moho, manchas, olores y daño UV al tablero y molduras</td>
+      </tr>
+      <tr class="border-b border-gray-200 bg-gray-50">
+        <td class="px-5 py-4 font-semibold text-[#0f2a4a]">Detallado Exterior Completo</td>
+        <td class="px-5 py-4 text-gray-700">Cada 3-4 meses</td>
+        <td class="px-5 py-4 text-gray-600">Protege contra oxidación, corrosión por sal, manchas de agua y adhesión de contaminantes</td>
+      </tr>
+      <tr class="border-b border-gray-200 bg-white">
+        <td class="px-5 py-4 font-semibold text-[#0f2a4a]">Detallado Completo</td>
+        <td class="px-5 py-4 text-gray-700">Cada 3-4 meses</td>
+        <td class="px-5 py-4 text-gray-600">Cuidado integral interior + exterior para máxima protección contra el clima de Florida</td>
+      </tr>
+      <tr class="border-b border-gray-200 bg-gray-50">
+        <td class="px-5 py-4 font-semibold text-[#0f2a4a]">Lavado de Mantenimiento</td>
+        <td class="px-5 py-4 text-gray-700">Cada 2 semanas</td>
+        <td class="px-5 py-4 text-gray-600">Elimina sal, polen, excrementos de aves y contaminantes superficiales entre detallados</td>
+      </tr>
+      <tr class="bg-white">
+        <td class="px-5 py-4 font-semibold text-[#0f2a4a]">Mantenimiento de Recubrimiento Cerámico</td>
+        <td class="px-5 py-4 text-gray-700">Cada 6 meses</td>
+        <td class="px-5 py-4 text-gray-600">Inspección, retoque y descontaminación completa (lavados cada 2 semanas aún necesarios)</td>
+      </tr>
+    </tbody>
+  </table>
+</div>
 
 ## Frecuencia de Detallado por Uso del Vehículo
 


### PR DESCRIPTION
Convert the subsection-based service schedule into a 3-column table (Service Type, Frequency, Key Benefits) with branded header row, alternating row colors, and shadow styling. Updated in both EN and ES.

https://claude.ai/code/session_01DixMpAEqcm3neXWcZxLGBL