### PR TITLE
Send quote form submissions to WhatsApp instead of Formspree

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -48,7 +48,7 @@ const services = [
         <!-- Contact Form -->
         <div>
           <h2 class="text-2xl font-bold text-[#0f2a4a] mb-6">Request a Free Quote</h2>
-          <form action="https://formspree.io/f/xyzgkqpw" method="POST" class="space-y-6">
+          <form id="quote-form" class="space-y-6">
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
                 <label for="name" class="block text-sm font-medium text-gray-700 mb-1">Name *</label>
@@ -123,15 +123,42 @@ const services = [
 
             <button
               type="submit"
-              class="w-full btn-accent text-lg py-4"
+              class="w-full btn-accent text-lg py-4 inline-flex items-center justify-center gap-2"
             >
-              Request Free Quote
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z"/>
+              </svg>
+              Request Free Quote via WhatsApp
             </button>
 
             <p class="text-sm text-gray-500 text-center">
-              We typically respond within 1-2 hours during business hours.
+              You'll be redirected to WhatsApp to send your quote request directly.
             </p>
           </form>
+
+          <script>
+            document.getElementById('quote-form').addEventListener('submit', function(e) {
+              e.preventDefault();
+
+              const name = document.getElementById('name').value.trim();
+              const phone = document.getElementById('phone').value.trim();
+              const email = document.getElementById('email').value.trim();
+              const service = document.getElementById('service').value;
+              const vehicle = document.getElementById('vehicle').value.trim();
+              const message = document.getElementById('message').value.trim();
+
+              let text = `Hi! I'd like to request a free quote for mobile car detailing.\n\n`;
+              text += `*Name:* ${name}\n`;
+              text += `*Phone:* ${phone}\n`;
+              if (email) text += `*Email:* ${email}\n`;
+              if (service) text += `*Service:* ${service}\n`;
+              if (vehicle) text += `*Vehicle:* ${vehicle}\n`;
+              if (message) text += `*Message:* ${message}\n`;
+
+              const whatsappUrl = `https://wa.me/17542152272?text=${encodeURIComponent(text)}`;
+              window.open(whatsappUrl, '_blank');
+            });
+          </script>
         </div>
 
         <!-- Contact Info -->

--- a/src/pages/es/contacto.astro
+++ b/src/pages/es/contacto.astro
@@ -49,7 +49,7 @@ const services = [
         <!-- Contact Form -->
         <div>
           <h2 class="text-2xl font-bold text-[#0f2a4a] mb-6">Solicita una Cotización Gratis</h2>
-          <form action="https://formspree.io/f/xyzgkqpw" method="POST" class="space-y-6">
+          <form id="quote-form" class="space-y-6">
             <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
                 <label for="name" class="block text-sm font-medium text-gray-700 mb-1">Nombre *</label>
@@ -124,15 +124,42 @@ const services = [
 
             <button
               type="submit"
-              class="w-full btn-accent text-lg py-4"
+              class="w-full btn-accent text-lg py-4 inline-flex items-center justify-center gap-2"
             >
-              Solicitar Cotización Gratis
+              <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24">
+                <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z"/>
+              </svg>
+              Solicitar Cotización Gratis por WhatsApp
             </button>
 
             <p class="text-sm text-gray-500 text-center">
-              Normalmente respondemos dentro de 1-2 horas durante horario laboral.
+              Serás redirigido a WhatsApp para enviar tu solicitud de cotización directamente.
             </p>
           </form>
+
+          <script>
+            document.getElementById('quote-form').addEventListener('submit', function(e) {
+              e.preventDefault();
+
+              const name = document.getElementById('name').value.trim();
+              const phone = document.getElementById('phone').value.trim();
+              const email = document.getElementById('email').value.trim();
+              const service = document.getElementById('service').value;
+              const vehicle = document.getElementById('vehicle').value.trim();
+              const message = document.getElementById('message').value.trim();
+
+              let text = `¡Hola! Me gustaría solicitar una cotización gratis para detallado de auto a domicilio.\n\n`;
+              text += `*Nombre:* ${name}\n`;
+              text += `*Teléfono:* ${phone}\n`;
+              if (email) text += `*Correo:* ${email}\n`;
+              if (service) text += `*Servicio:* ${service}\n`;
+              if (vehicle) text += `*Vehículo:* ${vehicle}\n`;
+              if (message) text += `*Mensaje:* ${message}\n`;
+
+              const whatsappUrl = `https://wa.me/17542152272?text=${encodeURIComponent(text)}`;
+              window.open(whatsappUrl, '_blank');
+            });
+          </script>
         </div>
 
         <!-- Contact Info -->


### PR DESCRIPTION
Replace Formspree POST handler with client-side WhatsApp redirect on both English and Spanish contact pages. Form data is composed into a formatted WhatsApp message and opened via wa.me link. Button now shows WhatsApp icon.

https://claude.ai/code/session_01XFxptR46oYu91TLpZJLYqP