### PR TITLE
Fix Cal.com embed by adding is:inline to script tags

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -42,7 +42,7 @@ const contactPageSchema = {
           </p>
           <div id="cal-booking-embed" style="width:100%; min-height:700px; overflow:auto;"></div>
 
-          <script>
+          <script is:inline>
             (function (C, A, L) {
               C[L] = C[L] || function () { (C[L].q = C[L].q || []).push(arguments); };
               var S = A.createElement('script');

--- a/src/pages/es/contacto.astro
+++ b/src/pages/es/contacto.astro
@@ -43,7 +43,7 @@ const contactPageSchema = {
           </p>
           <div id="cal-booking-embed" style="width:100%; min-height:700px; overflow:auto;"></div>
 
-          <script>
+          <script is:inline>
             (function (C, A, L) {
               C[L] = C[L] || function () { (C[L].q = C[L].q || []).push(arguments); };
               var S = A.createElement('script');


### PR DESCRIPTION
Astro processes and bundles <script> tags by default, which breaks the Cal.com embed IIFE pattern. Adding is:inline tells Astro to leave the script untouched so the embed loads correctly.

https://claude.ai/code/session_01DLqUVCGhm7URarZzKj7mkX