### PR TITLE
Update Cal.com embed to modern snippet with app.cal.com origin

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -44,25 +44,39 @@ const contactPageSchema = {
 
           <script is:inline>
             (function (C, A, L) {
-              C[L] = C[L] || function () { (C[L].q = C[L].q || []).push(arguments); };
-              var S = A.createElement('script');
-              S.async = true;
-              S.src = 'https://cal.com/embed/embed.js';
-              var H = A.getElementsByTagName('script')[0];
-              H.parentNode.insertBefore(S, H);
-            })(window, document, 'Cal');
+              let p = function (a, ar) { a.q.push(ar); };
+              let d = C.document;
+              C.Cal = C.Cal || function () {
+                let cal = C.Cal; let ar = arguments;
+                if (!cal.loaded) {
+                  cal.ns = {}; cal.q = cal.q || [];
+                  d.head.appendChild(d.createElement("script")).src = A;
+                  cal.loaded = true;
+                }
+                if (ar[0] === L) {
+                  const api = function () { p(api, arguments); };
+                  const namespace = ar[1]; api.q = api.q || [];
+                  if (typeof namespace === "string") {
+                    cal.ns[namespace] = cal.ns[namespace] || api;
+                    p(cal.ns[namespace], ar); p(cal, ["initNamespace", namespace]);
+                  } else p(cal, ar);
+                  return;
+                }
+                p(cal, ar);
+              };
+            })(window, "https://app.cal.com/embed/embed.js", "init");
+
+            Cal("init", { origin: "https://app.cal.com" });
 
             Cal("inline", {
               elementOrSelector: "#cal-booking-embed",
               calLink: "route95mobilecardetailingcom",
-              config: { theme: "light" }
+              layout: "month_view"
             });
 
             Cal("ui", {
-              theme: "light",
-              cssVarsPerTheme: {
-                light: { "cal-brand": "#0f2a4a" }
-              }
+              styles: { branding: { brandColor: "#0f2a4a" } },
+              hideEventTypeDetails: false
             });
           </script>
         </div>

--- a/src/pages/es/contacto.astro
+++ b/src/pages/es/contacto.astro
@@ -45,25 +45,39 @@ const contactPageSchema = {
 
           <script is:inline>
             (function (C, A, L) {
-              C[L] = C[L] || function () { (C[L].q = C[L].q || []).push(arguments); };
-              var S = A.createElement('script');
-              S.async = true;
-              S.src = 'https://cal.com/embed/embed.js';
-              var H = A.getElementsByTagName('script')[0];
-              H.parentNode.insertBefore(S, H);
-            })(window, document, 'Cal');
+              let p = function (a, ar) { a.q.push(ar); };
+              let d = C.document;
+              C.Cal = C.Cal || function () {
+                let cal = C.Cal; let ar = arguments;
+                if (!cal.loaded) {
+                  cal.ns = {}; cal.q = cal.q || [];
+                  d.head.appendChild(d.createElement("script")).src = A;
+                  cal.loaded = true;
+                }
+                if (ar[0] === L) {
+                  const api = function () { p(api, arguments); };
+                  const namespace = ar[1]; api.q = api.q || [];
+                  if (typeof namespace === "string") {
+                    cal.ns[namespace] = cal.ns[namespace] || api;
+                    p(cal.ns[namespace], ar); p(cal, ["initNamespace", namespace]);
+                  } else p(cal, ar);
+                  return;
+                }
+                p(cal, ar);
+              };
+            })(window, "https://app.cal.com/embed/embed.js", "init");
+
+            Cal("init", { origin: "https://app.cal.com" });
 
             Cal("inline", {
               elementOrSelector: "#cal-booking-embed",
               calLink: "route95mobilecardetailingcom",
-              config: { theme: "light" }
+              layout: "month_view"
             });
 
             Cal("ui", {
-              theme: "light",
-              cssVarsPerTheme: {
-                light: { "cal-brand": "#0f2a4a" }
-              }
+              styles: { branding: { brandColor: "#0f2a4a" } },
+              hideEventTypeDetails: false
             });
           </script>
         </div>


### PR DESCRIPTION
The old embed snippet used cal.com/embed/embed.js with a basic IIFE pattern that caused an infinite spinner. Updated to the current Cal.com recommended embed code which uses app.cal.com/embed/embed.js, proper init with origin, and namespace support.

https://claude.ai/code/session_01DLqUVCGhm7URarZzKj7mkX