### PR TITLE
Remove "Get a Free Quote" and "Request a Quote" buttons sitewide

### DIFF
--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -96,9 +96,6 @@ const articleSchema = {
           </svg>
           {t.serviceLayout.call}
         </a>
-        <a href={contactUrl} class="bg-white text-[#0f2a4a] px-6 py-3 rounded-md font-semibold hover:bg-gray-100 transition-colors">
-          {t.serviceLayout.requestAQuote}
-        </a>
       </div>
     </div>
   </section>

--- a/src/layouts/ServiceLayout.astro
+++ b/src/layouts/ServiceLayout.astro
@@ -68,9 +68,6 @@ const serviceAreaLinks = [
           </svg>
           {t.serviceLayout.call}
         </a>
-        <a href={contactUrl} class="bg-white text-[#0f2a4a] px-6 py-3 rounded-md font-semibold text-center hover:bg-gray-100 transition-colors">
-          {t.serviceLayout.getAFreeQuote}
-        </a>
       </div>
     </div>
   </section>
@@ -148,9 +145,6 @@ const serviceAreaLinks = [
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
           </svg>
           {t.serviceLayout.call}
-        </a>
-        <a href={contactUrl} class="bg-white text-[#0f2a4a] px-6 py-3 rounded-md font-semibold hover:bg-gray-100 transition-colors">
-          {t.serviceLayout.getAFreeQuote}
         </a>
       </div>
     </div>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -231,9 +231,6 @@ const aboutPageSchema = {
           </svg>
           Call 754-215-2272
         </a>
-        <a href={`${base}contact/`} class="bg-white text-[#0f2a4a] px-6 py-3 rounded-md font-semibold hover:bg-gray-100 transition-colors">
-          Request a Quote
-        </a>
       </div>
     </div>
   </section>

--- a/src/pages/areas.astro
+++ b/src/pages/areas.astro
@@ -87,9 +87,6 @@ const cities = [
           </svg>
           Call 754-215-2272
         </a>
-        <a href={`${base}contact/`} class="bg-white text-[#0f2a4a] px-6 py-3 rounded-md font-semibold text-center hover:bg-gray-100 transition-colors">
-          Get a Free Quote
-        </a>
       </div>
     </div>
   </section>
@@ -151,9 +148,6 @@ const cities = [
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
           </svg>
           Call 754-215-2272
-        </a>
-        <a href={`${base}contact/`} class="bg-white text-[#0f2a4a] px-6 py-3 rounded-md font-semibold hover:bg-gray-100 transition-colors">
-          Request a Quote Online
         </a>
       </div>
     </div>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -80,9 +80,6 @@ const blogSchema = {
           </svg>
           Call 754-215-2272
         </a>
-        <a href="/contact/" class="bg-white text-[#0f2a4a] px-6 py-3 rounded-md font-semibold hover:bg-gray-100 transition-colors">
-          Request a Quote
-        </a>
       </div>
     </div>
   </section>

--- a/src/pages/es/areas.astro
+++ b/src/pages/es/areas.astro
@@ -88,9 +88,6 @@ const cities = [
           </svg>
           Llamar 754-215-2272
         </a>
-        <a href={localizedUrl('es', 'contact')} class="bg-white text-[#0f2a4a] px-6 py-3 rounded-md font-semibold text-center hover:bg-gray-100 transition-colors">
-          Cotización Gratis
-        </a>
       </div>
     </div>
   </section>
@@ -152,9 +149,6 @@ const cities = [
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
           </svg>
           Llamar 754-215-2272
-        </a>
-        <a href={localizedUrl('es', 'contact')} class="bg-white text-[#0f2a4a] px-6 py-3 rounded-md font-semibold hover:bg-gray-100 transition-colors">
-          Solicitar Cotización
         </a>
       </div>
     </div>

--- a/src/pages/es/blog/index.astro
+++ b/src/pages/es/blog/index.astro
@@ -80,9 +80,6 @@ const blogSchema = {
           </svg>
           Llamar 754-215-2272
         </a>
-        <a href="/es/contacto/" class="bg-white text-[#0f2a4a] px-6 py-3 rounded-md font-semibold hover:bg-gray-100 transition-colors">
-          Solicitar Cotización
-        </a>
       </div>
     </div>
   </section>

--- a/src/pages/es/detallado-movil-dania-beach.astro
+++ b/src/pages/es/detallado-movil-dania-beach.astro
@@ -113,9 +113,6 @@ const packages = [
           </svg>
           Llama al 754-215-2272
         </a>
-        <a href={localizedUrl('es', 'contact')} class="bg-white text-[#0f2a4a] px-6 py-3 rounded-md font-semibold text-center hover:bg-gray-100 transition-colors">
-          Obtén una Cotización Gratis
-        </a>
       </div>
     </div>
   </section>
@@ -252,9 +249,6 @@ const packages = [
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
           </svg>
           Llama al 754-215-2272
-        </a>
-        <a href={localizedUrl('es', 'contact')} class="bg-white text-[#0f2a4a] px-6 py-3 rounded-md font-semibold hover:bg-gray-100 transition-colors">
-          Solicita una Cotización en Línea
         </a>
       </div>
     </div>

--- a/src/pages/es/detallado-movil-hollywood-fl.astro
+++ b/src/pages/es/detallado-movil-hollywood-fl.astro
@@ -113,9 +113,6 @@ const packages = [
           </svg>
           Llama al 754-215-2272
         </a>
-        <a href={localizedUrl('es', 'contact')} class="bg-white text-[#0f2a4a] px-6 py-3 rounded-md font-semibold text-center hover:bg-gray-100 transition-colors">
-          Obtén una Cotización Gratis
-        </a>
       </div>
     </div>
   </section>
@@ -252,9 +249,6 @@ const packages = [
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
           </svg>
           Llama al 754-215-2272
-        </a>
-        <a href={localizedUrl('es', 'contact')} class="bg-white text-[#0f2a4a] px-6 py-3 rounded-md font-semibold hover:bg-gray-100 transition-colors">
-          Solicita una Cotización en Línea
         </a>
       </div>
     </div>

--- a/src/pages/es/detallado-movil-pompano-beach.astro
+++ b/src/pages/es/detallado-movil-pompano-beach.astro
@@ -113,9 +113,6 @@ const packages = [
           </svg>
           Llama al 754-215-2272
         </a>
-        <a href={localizedUrl('es', 'contact')} class="bg-white text-[#0f2a4a] px-6 py-3 rounded-md font-semibold text-center hover:bg-gray-100 transition-colors">
-          Obtén una Cotización Gratis
-        </a>
       </div>
     </div>
   </section>
@@ -252,9 +249,6 @@ const packages = [
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
           </svg>
           Llama al 754-215-2272
-        </a>
-        <a href={localizedUrl('es', 'contact')} class="bg-white text-[#0f2a4a] px-6 py-3 rounded-md font-semibold hover:bg-gray-100 transition-colors">
-          Solicita una Cotización en Línea
         </a>
       </div>
     </div>

--- a/src/pages/es/index.astro
+++ b/src/pages/es/index.astro
@@ -85,9 +85,6 @@ const websiteSchema = {
             </svg>
             Llama al<br/>754-215-2272
           </a>
-          <a href={localizedUrl('es', 'contact')} class="bg-white text-[#0f2a4a] px-6 py-3 rounded-md font-semibold text-center text-lg flex items-center justify-center hover:bg-gray-100 transition-colors sm:flex-1">
-            Obtén una<br/>Cotización Gratis
-          </a>
         </div>
         <p class="mt-6 text-[#c0c7cf] font-semibold">
           Servicio el mismo día disponible para el área de Fort Lauderdale
@@ -276,9 +273,6 @@ const websiteSchema = {
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
           </svg>
           Llama al<br/>754-215-2272
-        </a>
-        <a href={localizedUrl('es', 'contact')} class="bg-white text-[#0f2a4a] px-6 py-3 rounded-md font-semibold text-lg flex items-center justify-center hover:bg-gray-100 transition-colors sm:flex-1 sm:max-w-[220px]">
-          Solicita una<br/>Cotización en Línea
         </a>
       </div>
       <p class="mt-6 text-[#c0c7cf]">

--- a/src/pages/es/nosotros.astro
+++ b/src/pages/es/nosotros.astro
@@ -224,9 +224,6 @@ const aboutPageSchema = {
           </svg>
           Llama al 754-215-2272
         </a>
-        <a href={localizedUrl('es', 'contact')} class="bg-white text-[#0f2a4a] px-6 py-3 rounded-md font-semibold hover:bg-gray-100 transition-colors">
-          Solicita una Cotización
-        </a>
       </div>
     </div>
   </section>

--- a/src/pages/es/servicios-de-detallado-fort-lauderdale.astro
+++ b/src/pages/es/servicios-de-detallado-fort-lauderdale.astro
@@ -455,9 +455,6 @@ const faqSchema = {
             </svg>
             Llama al 754-215-2272
           </a>
-          <a href={localizedUrl('es', 'contact')} class="bg-white border-2 border-[#0f2a4a] text-[#0f2a4a] px-6 py-3 rounded-md font-semibold hover:bg-gray-50 transition-colors">
-            Solicitar Cotización en Línea
-          </a>
         </div>
       </div>
     </div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -84,9 +84,6 @@ const websiteSchema = {
             </svg>
             Call<br/>754-215-2272
           </a>
-          <a href={`${base}contact/`} class="bg-white text-[#0f2a4a] px-6 py-3 rounded-md font-semibold text-center text-lg flex items-center justify-center hover:bg-gray-100 transition-colors sm:flex-1">
-            Get a Free Quote
-          </a>
         </div>
         <p class="mt-6 text-[#c0c7cf] font-semibold">
           Same-day service available for Fort Lauderdale area
@@ -275,9 +272,6 @@ const websiteSchema = {
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
           </svg>
           Call<br/>754-215-2272
-        </a>
-        <a href={`${base}contact/`} class="bg-white text-[#0f2a4a] px-6 py-3 rounded-md font-semibold text-lg flex items-center justify-center hover:bg-gray-100 transition-colors sm:flex-1 sm:max-w-[220px]">
-          Request a Quote Online
         </a>
       </div>
       <p class="mt-6 text-[#c0c7cf]">

--- a/src/pages/mobile-car-detailing-dania-beach.astro
+++ b/src/pages/mobile-car-detailing-dania-beach.astro
@@ -112,9 +112,6 @@ const packages = [
           </svg>
           Call 754-215-2272
         </a>
-        <a href={`${base}contact/`} class="bg-white text-[#0f2a4a] px-6 py-3 rounded-md font-semibold text-center hover:bg-gray-100 transition-colors">
-          Get a Free Quote
-        </a>
       </div>
     </div>
   </section>
@@ -255,9 +252,6 @@ const packages = [
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
           </svg>
           Call 754-215-2272
-        </a>
-        <a href={`${base}contact/`} class="bg-white text-[#0f2a4a] px-6 py-3 rounded-md font-semibold hover:bg-gray-100 transition-colors">
-          Request a Quote Online
         </a>
       </div>
     </div>

--- a/src/pages/mobile-car-detailing-hollywood-fl.astro
+++ b/src/pages/mobile-car-detailing-hollywood-fl.astro
@@ -112,9 +112,6 @@ const packages = [
           </svg>
           Call 754-215-2272
         </a>
-        <a href={`${base}contact/`} class="bg-white text-[#0f2a4a] px-6 py-3 rounded-md font-semibold text-center hover:bg-gray-100 transition-colors">
-          Get a Free Quote
-        </a>
       </div>
     </div>
   </section>
@@ -255,9 +252,6 @@ const packages = [
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
           </svg>
           Call 754-215-2272
-        </a>
-        <a href={`${base}contact/`} class="bg-white text-[#0f2a4a] px-6 py-3 rounded-md font-semibold hover:bg-gray-100 transition-colors">
-          Request a Quote Online
         </a>
       </div>
     </div>

--- a/src/pages/mobile-car-detailing-pompano-beach.astro
+++ b/src/pages/mobile-car-detailing-pompano-beach.astro
@@ -112,9 +112,6 @@ const packages = [
           </svg>
           Call 754-215-2272
         </a>
-        <a href={`${base}contact/`} class="bg-white text-[#0f2a4a] px-6 py-3 rounded-md font-semibold text-center hover:bg-gray-100 transition-colors">
-          Get a Free Quote
-        </a>
       </div>
     </div>
   </section>
@@ -255,9 +252,6 @@ const packages = [
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
           </svg>
           Call 754-215-2272
-        </a>
-        <a href={`${base}contact/`} class="bg-white text-[#0f2a4a] px-6 py-3 rounded-md font-semibold hover:bg-gray-100 transition-colors">
-          Request a Quote Online
         </a>
       </div>
     </div>


### PR DESCRIPTION
These quote buttons are no longer needed since the booking flow now goes directly to the contact page. Removes buttons from ServiceLayout, BlogLayout, index, about, areas, blog, location pages, and all Spanish equivalents.

https://claude.ai/code/session_01G3CiuAkwN2Qg3oBAXYxhjx