### PR TITLE
Make Email Us button same width as Call button on FAQ page

### DIFF
--- a/src/pages/faq.astro
+++ b/src/pages/faq.astro
@@ -508,7 +508,7 @@ const faqSchema = {
           </svg>
           Call 754-215-2272
         </a>
-        <a href="mailto:contact@route95mobilecardetailing.com" class="inline-flex items-center justify-center gap-2 bg-white text-[#0f2a4a] font-semibold px-6 py-3 rounded-lg hover:bg-gray-100 transition-colors">
+        <a href="mailto:contact@route95mobilecardetailing.com" class="inline-flex items-center justify-center gap-2 bg-white text-[#0f2a4a] font-semibold px-6 py-3 rounded-lg hover:bg-gray-100 transition-colors sm:w-64">
           <svg xmlns="http://www.w3.org/2000/svg" class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
           </svg>


### PR DESCRIPTION
Add sm:w-64 to the Email Us button to match the Call button size.

https://claude.ai/code/session_01CpS8aWyV1CF6z2ZP3kWann