### PR TITLE
Fix meta descriptions exceeding 160 characters for SEO compliance

### DIFF
--- a/src/pages/car-detailing-services-fort-lauderdale.astro
+++ b/src/pages/car-detailing-services-fort-lauderdale.astro
@@ -9,7 +9,7 @@ const whatsappMessage = "Hi! I'd like to get a quote for mobile car detailing.";
 const whatsappUrl = `https://wa.me/${whatsappNumber}?text=${encodeURIComponent(whatsappMessage)}`;
 
 const title = "Car Detailing Services Fort Lauderdale | Mobile | Route95";
-const description = "Mobile car detailing packages in Fort Lauderdale. Quick Wash, Fresh Start, Complete Clean & Premium Refresh. Compare packages, add-ons & pricing. Call 754-215-2272.";
+const description = "Mobile car detailing packages in Fort Lauderdale. Quick Wash, Fresh Start, Complete Clean & Premium Refresh. Compare packages & pricing.";
 
 const siteUrl = "https://route95mobilecardetailing.com";
 const categorySchema = {

--- a/src/pages/complete-clean-fort-lauderdale.astro
+++ b/src/pages/complete-clean-fort-lauderdale.astro
@@ -4,7 +4,7 @@ import ProcessSteps from '../components/ProcessSteps.astro';
 
 const base = import.meta.env.BASE_URL;
 const title = "Complete Clean Fort Lauderdale | Mobile Detailing | Route95";
-const description = "Complete Clean mobile detailing in Fort Lauderdale. Our most thorough package — inside and out, trunk included. From $130. 10% OFF Feb & March 2026. Call 754-215-2272";
+const description = "Complete Clean mobile detailing in Fort Lauderdale. Our most thorough package — inside and out, trunk included. From $130. Call 754-215-2272.";
 
 const parentCategory = {
   href: `${base}car-detailing-services-fort-lauderdale/`,

--- a/src/pages/es/eliminacion-de-insectos-y-alquitran-fort-lauderdale.astro
+++ b/src/pages/es/eliminacion-de-insectos-y-alquitran-fort-lauderdale.astro
@@ -5,7 +5,7 @@ import { localizedUrl } from '../../i18n/utils';
 
 const url = (slug: string) => localizedUrl('es', slug);
 const title = "Eliminacion de Insectos y Brea Fort Lauderdale | Route95";
-const description = "Eliminacion profesional de insectos y brea en Fort Lauderdale. Remocion segura sin danar la pintura, restaure el acabado liso. Servicio movil - vamos a usted! Llame al 754-215-2272";
+const description = "Eliminación profesional de insectos y brea en Fort Lauderdale. Remoción segura sin dañar la pintura. Servicio móvil — vamos a usted!";
 
 const parentCategory = {
   href: url('car-wash-fort-lauderdale'),

--- a/src/pages/es/lavado-de-autos-fort-lauderdale.astro
+++ b/src/pages/es/lavado-de-autos-fort-lauderdale.astro
@@ -10,7 +10,7 @@ const whatsappMessage = "¡Hola! Me gustaría obtener una cotización para detal
 const whatsappUrl = `https://wa.me/${whatsappNumber}?text=${encodeURIComponent(whatsappMessage)}`;
 
 const title = "Lavado de Autos Fort Lauderdale | Servicio Móvil | Route95";
-const description = "Lavado de autos a domicilio en Fort Lauderdale. Vamos a tu casa u oficina con todo el equipo. Lavado a mano, encerado, barra de arcilla, limpieza de rines. Mismo día disponible. Llama al 754-215-2272.";
+const description = "Lavado de autos a domicilio en Fort Lauderdale. Vamos a tu casa u oficina. Lavado a mano, encerado, barra de arcilla, limpieza de rines.";
 
 const siteUrl = "https://route95mobilecardetailing.com";
 const categorySchema = {

--- a/src/pages/es/limpieza-de-tapiceria-fort-lauderdale.astro
+++ b/src/pages/es/limpieza-de-tapiceria-fort-lauderdale.astro
@@ -10,7 +10,7 @@ const whatsappMessage = "¡Hola! Me gustaría obtener una cotización para detal
 const whatsappUrl = `https://wa.me/${whatsappNumber}?text=${encodeURIComponent(whatsappMessage)}`;
 
 const title = "Limpieza de Tapicería Fort Lauderdale | Servicio Móvil | Route95";
-const description = "Limpieza de tapicería a domicilio en Fort Lauderdale. Asientos, alfombras, cuero, eliminación de olores. Vamos a ti con equipo profesional. Mismo día disponible. Llama al 754-215-2272.";
+const description = "Limpieza de tapicería a domicilio en Fort Lauderdale. Asientos, alfombras, cuero, eliminación de olores. Vamos a ti con equipo profesional.";
 
 const siteUrl = "https://route95mobilecardetailing.com";
 const categorySchema = {

--- a/src/pages/es/servicios-de-detallado-fort-lauderdale.astro
+++ b/src/pages/es/servicios-de-detallado-fort-lauderdale.astro
@@ -10,7 +10,7 @@ const whatsappMessage = "¡Hola! Me gustaría obtener una cotización para detal
 const whatsappUrl = `https://wa.me/${whatsappNumber}?text=${encodeURIComponent(whatsappMessage)}`;
 
 const title = "Servicios de Detallado Fort Lauderdale | Route95";
-const description = "Paquetes de detallado de autos a domicilio en Fort Lauderdale. Lavado Rápido, Nuevo Comienzo, Limpieza Completa y Renovación Premium. Compara paquetes, extras y precios. Llama al 754-215-2272.";
+const description = "Paquetes de detallado de autos a domicilio en Fort Lauderdale. Lavado Rápido, Nuevo Comienzo, Limpieza Completa y Renovación Premium.";
 
 const packages = [
   {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,7 +8,7 @@ const title = "Mobile Car Detailing Fort Lauderdale | Route95";
 const whatsappNumber = "17542152272";
 const whatsappMessage = "Hi! I'd like to get a quote for mobile car detailing.";
 const whatsappUrl = `https://wa.me/${whatsappNumber}?text=${encodeURIComponent(whatsappMessage)}`;
-const description = "Professional mobile car detailing in Fort Lauderdale. We come to you! Same-day service available. Serving Fort Lauderdale, Dania Beach, Hollywood & Pompano Beach. Call 754-215-2272";
+const description = "Professional mobile car detailing in Fort Lauderdale. We come to you! Same-day service. Serving Dania Beach, Hollywood & Pompano Beach.";
 
 const categories = [
   {

--- a/src/pages/premium-refresh-fort-lauderdale.astro
+++ b/src/pages/premium-refresh-fort-lauderdale.astro
@@ -3,7 +3,7 @@ import ServiceLayout from '../layouts/ServiceLayout.astro';
 
 const base = import.meta.env.BASE_URL;
 const title = "Premium Refresh Fort Lauderdale | Mobile Detailing | Route95";
-const description = "Premium Refresh mobile detailing in Fort Lauderdale from $400. Deep interior shampoo, steam cleaning, car waxing, door jambs & complete exterior detail. 15% off Feb & March. Call 754-215-2272";
+const description = "Premium Refresh mobile detailing in Fort Lauderdale from $400. Deep interior shampoo, steam cleaning, car waxing, door jambs & complete exterior detail.";
 
 const parentCategory = {
   href: `${base}car-detailing-services-fort-lauderdale/`,

--- a/src/pages/smoke-odor-removal-fort-lauderdale.astro
+++ b/src/pages/smoke-odor-removal-fort-lauderdale.astro
@@ -4,7 +4,7 @@ import ProcessSteps from '../components/ProcessSteps.astro';
 
 const base = import.meta.env.BASE_URL;
 const title = "Smoke Odor Removal Fort Lauderdale & Pompano Beach | Car Smoke Smell Elimination | Route95";
-const description = "Professional car smoke odor removal in Fort Lauderdale and Pompano Beach. Cigarette smell elimination using ozone treatment and deep cleaning. Mobile service — we come to you! Call 754-215-2272";
+const description = "Professional car smoke odor removal in Fort Lauderdale. Cigarette smell elimination using ozone treatment and deep cleaning. We come to you!";
 
 const parentCategory = {
   href: `${base}upholstery-cleaning-fort-lauderdale/`,


### PR DESCRIPTION
Bing flagged the homepage meta description as too long. Shortened descriptions on 9 pages (homepage + 4 English + 4 Spanish service pages) to stay within the 25-160 character limit required by search engines. Removed phone numbers and promotional text to fit.

https://claude.ai/code/session_01Q2VWY7C9Q6uWRXnVXWa7TL