### PR TITLE
Add 404 page to fix Cloudflare Pages soft-404 returning homepage

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -14,6 +14,7 @@ export default defineConfig({
       changefreq: 'weekly',
       priority: 0.7,
       lastmod: new Date(),
+      filter: (page) => !page.includes('/404/') && !page.endsWith('/404'),
       serialize(item) {
         // Homepage — highest priority
         if (item.url.match(/\.com\/$/) || item.url.match(/\.com\/es\/$/)) {

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,47 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+const title = "Page Not Found (404) | Route95 Mobile Car Detailing";
+const description = "The page you're looking for doesn't exist. Browse our mobile car detailing services in Fort Lauderdale, Dania Beach, Hollywood, and Pompano Beach.";
+---
+
+<BaseLayout title={title} description={description}>
+  <section class="bg-gradient-to-br from-[#0c2448] to-[#1a5ca0] text-white py-20 lg:py-28">
+    <div class="max-w-3xl mx-auto px-4 text-center">
+      <p class="text-7xl lg:text-8xl font-bold mb-4">404</p>
+      <h1 class="text-3xl lg:text-4xl font-bold mb-6">Page Not Found</h1>
+      <p class="text-xl text-gray-200 mb-10">
+        We couldn't find the page you're looking for. It may have moved or no longer exists. Let's get you back on the road.
+      </p>
+      <div class="flex flex-col sm:flex-row gap-4 justify-center">
+        <a href="/" class="btn-accent text-lg">Back to Home</a>
+        <a href="tel:+17542152272" class="btn-accent text-lg flex items-center justify-center gap-2">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
+          </svg>
+          Call 754-215-2272
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 lg:py-20">
+    <div class="max-w-5xl mx-auto px-4">
+      <h2 class="text-2xl lg:text-3xl font-bold text-[#0f2a4a] mb-8 text-center">Popular Services</h2>
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <a href="/car-wash-fort-lauderdale/" class="service-card bg-white rounded-xl shadow-lg p-6 group">
+          <h3 class="text-xl font-bold text-[#0f2a4a] mb-3 group-hover:text-[#1a3d6b] transition-colors">Car Wash</h3>
+          <p class="text-gray-600">Hand wash, waxing, clay bar treatment, wheel cleaning, and more.</p>
+        </a>
+        <a href="/interior-car-detailing-fort-lauderdale/" class="service-card bg-white rounded-xl shadow-lg p-6 group">
+          <h3 class="text-xl font-bold text-[#0f2a4a] mb-3 group-hover:text-[#1a3d6b] transition-colors">Interior Detailing</h3>
+          <p class="text-gray-600">Seat shampooing, leather cleaning, carpet cleaning, odor removal.</p>
+        </a>
+        <a href="/car-detailing-services-fort-lauderdale/" class="service-card bg-white rounded-xl shadow-lg p-6 group">
+          <h3 class="text-xl font-bold text-[#0f2a4a] mb-3 group-hover:text-[#1a3d6b] transition-colors">Detailing Packages</h3>
+          <p class="text-gray-600">Quick Wash, Fresh Start, Complete Clean & Premium Refresh.</p>
+        </a>
+      </div>
+    </div>
+  </section>
+</BaseLayout>

--- a/src/pages/es/404.astro
+++ b/src/pages/es/404.astro
@@ -1,0 +1,47 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+const title = "Página No Encontrada (404) | Route95 Mobile Car Detailing";
+const description = "La página que busca no existe. Explore nuestros servicios de detallado móvil de autos en Fort Lauderdale, Dania Beach, Hollywood y Pompano Beach.";
+---
+
+<BaseLayout title={title} description={description}>
+  <section class="bg-gradient-to-br from-[#0c2448] to-[#1a5ca0] text-white py-20 lg:py-28">
+    <div class="max-w-3xl mx-auto px-4 text-center">
+      <p class="text-7xl lg:text-8xl font-bold mb-4">404</p>
+      <h1 class="text-3xl lg:text-4xl font-bold mb-6">Página No Encontrada</h1>
+      <p class="text-xl text-gray-200 mb-10">
+        No pudimos encontrar la página que busca. Puede haberse movido o ya no existe. Lo ayudamos a volver al camino correcto.
+      </p>
+      <div class="flex flex-col sm:flex-row gap-4 justify-center">
+        <a href="/es/" class="btn-accent text-lg">Volver al Inicio</a>
+        <a href="tel:+17542152272" class="btn-accent text-lg flex items-center justify-center gap-2">
+          <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
+          </svg>
+          Llamar 754-215-2272
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <section class="py-16 lg:py-20">
+    <div class="max-w-5xl mx-auto px-4">
+      <h2 class="text-2xl lg:text-3xl font-bold text-[#0f2a4a] mb-8 text-center">Servicios Populares</h2>
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-6">
+        <a href="/es/lavado-de-autos-fort-lauderdale/" class="service-card bg-white rounded-xl shadow-lg p-6 group">
+          <h3 class="text-xl font-bold text-[#0f2a4a] mb-3 group-hover:text-[#1a3d6b] transition-colors">Lavado de Autos</h3>
+          <p class="text-gray-600">Lavado a mano, encerado, tratamiento de barra de arcilla, limpieza de rines y más.</p>
+        </a>
+        <a href="/es/detallado-interior-fort-lauderdale/" class="service-card bg-white rounded-xl shadow-lg p-6 group">
+          <h3 class="text-xl font-bold text-[#0f2a4a] mb-3 group-hover:text-[#1a3d6b] transition-colors">Detallado Interior</h3>
+          <p class="text-gray-600">Lavado de asientos, limpieza de cuero, lavado de alfombras, eliminación de olores.</p>
+        </a>
+        <a href="/es/servicios-de-detallado-fort-lauderdale/" class="service-card bg-white rounded-xl shadow-lg p-6 group">
+          <h3 class="text-xl font-bold text-[#0f2a4a] mb-3 group-hover:text-[#1a3d6b] transition-colors">Paquetes de Detallado</h3>
+          <p class="text-gray-600">Lavado Rápido, Nuevo Comienzo, Limpieza Completa y Renovación Premium.</p>
+        </a>
+      </div>
+    </div>
+  </section>
+</BaseLayout>


### PR DESCRIPTION
Without a 404.html in the build output, Cloudflare Pages was serving index.html with HTTP 200 for unmatched routes, causing Google to flag non-existent URLs (e.g. /blog/<es-slug>/) as "Alternate page with proper canonical tag" since they all canonicalized to the homepage.

Astro builds 404.astro to dist/404.html, which Cloudflare Pages auto-serves with HTTP 404. Also added Spanish counterpart at /es/404/ per bilingual rule, and excluded both from the sitemap.