### PR TITLE
Update StarkRank outgoing links to new URL structure

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -33,7 +33,7 @@ const base = import.meta.env.BASE_URL;
           <span class="font-semibold">{t.footer.satisfactionGuaranteed}</span>
         </div>
         <div class="mt-2">
-          <a href="https://starkrank.com/" target="_blank" rel="noopener noreferrer" class="text-[#c0c7cf] hover:text-white text-sm">Website by StarkRank</a>
+          <a href="https://starkrank.com/en/" target="_blank" rel="noopener noreferrer" class="text-[#c0c7cf] hover:text-white text-sm">Website by StarkRank</a>
         </div>
       </div>
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -51,7 +51,7 @@ const aboutPageSchema = {
             Living in Fort Lauderdale means understanding what the South Florida environment does to vehicles. The intense sun fades paint and cracks interiors. Salt air from the Atlantic corrodes metal and chrome. Humidity breeds mold and mildew inside cabins.
           </p>
           <p class="text-gray-600 mb-4">
-            We built our service specifically for these challenges. Every product we use, every technique we employ is chosen because it works in Florida conditions. We detail cars here every day, from the luxury homes in Las Olas to the waterfront properties in Nurmi Isles. To reach more customers in Fort Lauderdale, we partnered with <a href="https://starkrank.com/services/seo-for-auto-services/" target="_blank" rel="noopener noreferrer" class="text-[#e63f05] hover:underline">StarkRank</a> to build our online presence and make sure locals can find us when they need mobile detailing.
+            We built our service specifically for these challenges. Every product we use, every technique we employ is chosen because it works in Florida conditions. We detail cars here every day, from the luxury homes in Las Olas to the waterfront properties in Nurmi Isles. To reach more customers in Fort Lauderdale, we partnered with <a href="https://starkrank.com/en/services/" target="_blank" rel="noopener noreferrer" class="text-[#e63f05] hover:underline">StarkRank</a> to build our online presence and make sure locals can find us when they need mobile detailing.
           </p>
           <p class="text-gray-600">
             Our mobile service means we come to your home, your office, or wherever your vehicle is located. You get professional results without the hassle of traditional detail shops.


### PR DESCRIPTION
## Summary
- Footer link updated from `https://starkrank.com/` to `https://starkrank.com/en/`
- About page link updated from `https://starkrank.com/services/seo-for-auto-services/` to `https://starkrank.com/en/services/`
- StarkRank changed their site structure; outgoing links needed to be adapted to avoid broken/redirected links

## Test plan
- [ ] Verify footer link resolves to `https://starkrank.com/en/` (visible on every page via shared `Footer.astro`)
- [ ] Verify about page link resolves to `https://starkrank.com/en/services/`
- [ ] Confirm both links open in a new tab with `rel="noopener noreferrer"` intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)