### PR TITLE
Convert URL redirects from Astro meta-refresh to Cloudflare 301

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -100,13 +100,6 @@ export default defineConfig({
       prefixDefaultLocale: false,
     },
   },
-  redirects: {
-    '/chrome-polishing-fort-lauderdale/': '/car-wash-fort-lauderdale/',
-    '/es/pulido-de-cromo-fort-lauderdale/': '/es/lavado-de-autos-fort-lauderdale/',
-    '/mobile-car-detailing-fort-lauderdale/': '/car-detailing-services-fort-lauderdale/',
-    '/upholstery-cleaning-fort-lauderdale/': '/auto-upholstery-cleaning-fort-lauderdale/',
-    '/es/limpieza-de-tapiceria-fort-lauderdale/': '/es/limpieza-de-tapiceria-de-autos-fort-lauderdale/',
-  },
   vite: {
     plugins: [tailwindcss()]
   }

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,12 @@
+# Cloudflare Pages 301 redirects.
+# Single source of truth — kept here (not in astro.config.mjs) because Astro's
+# static-output `redirects:` produces meta-refresh HTML, not real 301s, and
+# Google consolidates index signals slower under meta-refresh.
+#
+# Format: from-path  to-path  status
+
+/chrome-polishing-fort-lauderdale/             /car-wash-fort-lauderdale/                              301
+/es/pulido-de-cromo-fort-lauderdale/           /es/lavado-de-autos-fort-lauderdale/                    301
+/mobile-car-detailing-fort-lauderdale/         /car-detailing-services-fort-lauderdale/                301
+/upholstery-cleaning-fort-lauderdale/          /auto-upholstery-cleaning-fort-lauderdale/              301
+/es/limpieza-de-tapiceria-fort-lauderdale/     /es/limpieza-de-tapiceria-de-autos-fort-lauderdale/     301

--- a/src/i18n/slugs.ts
+++ b/src/i18n/slugs.ts
@@ -15,7 +15,6 @@ export const slugMap: Record<string, string> = {
   'trim-restoration-fort-lauderdale': 'restauracion-de-molduras-fort-lauderdale',
   'tire-dressing-fort-lauderdale': 'acondicionador-de-llantas-fort-lauderdale',
   'bug-and-tar-removal-fort-lauderdale': 'eliminacion-de-insectos-y-alquitran-fort-lauderdale',
-  'upholstery-cleaning-fort-lauderdale': 'limpieza-de-tapiceria-fort-lauderdale', // redirected to interior-car-detailing
   'auto-upholstery-cleaning-fort-lauderdale': 'limpieza-de-tapiceria-de-autos-fort-lauderdale',
   'seat-shampooing-fort-lauderdale': 'lavado-de-asientos-fort-lauderdale',
   'carpet-shampooing-fort-lauderdale': 'lavado-de-alfombras-fort-lauderdale',


### PR DESCRIPTION
## Summary

- Moves 5 legacy-URL redirects from `astro.config.mjs` to `public/_redirects` so Cloudflare Pages emits real 301s instead of Astro's meta-refresh + canonical pages (HTTP 200).
- Single source of truth: deletes the `redirects: { … }` block from `astro.config.mjs` and removes one orphan entry from `src/i18n/slugs.ts` that no other code referenced.

## Why

Astro's static-output `redirects:` config doesn't produce HTTP 301 — it generates an HTML page with `<meta http-equiv="refresh">` + `<link rel="canonical">` + `robots:noindex`. Google follows it but consolidates index signals slower than under a real 301. Concrete evidence: `/upholstery-cleaning-fort-lauderdale/` (the legacy hub URL, since renamed to `interior-car-detailing`) still attracted **554 impressions in the last 90 days** vs. 168 on its canonical destination `/auto-upholstery-cleaning-fort-lauderdale/`. A real 301 should accelerate that consolidation.

## Test plan

- [x] `npm run build` passes locally — 96 pages, no legacy-URL `index.html` generated in `dist/`, `dist/_redirects` present (829 B), sitemap free of legacy URLs.
- [ ] After Cloudflare Pages auto-deploy on merge: `curl -sI https://route95mobilecardetailing.com/upholstery-cleaning-fort-lauderdale/` returns `HTTP/2 301` with `location: /auto-upholstery-cleaning-fort-lauderdale/`. Same for the other 4 redirects.
- [ ] In GSC, submit URL inspection on the 5 legacy URLs to nudge re-crawl; expect "Not on Google" within 1–2 weeks as consolidation completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)