### PR TITLE
NeuronWriter optimization: engine bay cleaning page

### DIFF
--- a/src/pages/engine-bay-cleaning-fort-lauderdale.astro
+++ b/src/pages/engine-bay-cleaning-fort-lauderdale.astro
@@ -57,10 +57,18 @@ const faqSchema = {
     },
     {
       "@type": "Question",
-      "name": "Why Clean Your Engine Bay?",
+      "name": "Is It Worth Getting Your Engine Bay Cleaned?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "A clean engine bay makes it easier to spot leaks, improves resale value, and shows buyers or mechanics the vehicle has been well maintained."
+        "text": "Yes — getting your engine bay cleaned is worth it for three reasons: it makes leaks easier to spot, it improves resale value, and it shows buyers or mechanics the vehicle has been well maintained."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can You Get an Engine Bay Cleaned at Home?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes — Route95's mobile detailing service comes to your driveway in Fort Lauderdale and cleans the engine bay on-site. The mobile setup is identical to a shop: same degreasers, same brushes, same low-pressure rinsing. The only difference is we come to you, which saves you the trip and the wait."
       }
     }
   ]
@@ -82,13 +90,13 @@ const schemas = [serviceSchema, faqSchema];
     <div class="lg:col-span-2 space-y-8">
       <section>
         <p class="text-gray-600 mb-4">
-          Most people never think about what's under the hood until something goes wrong. Grease, road grime, dirt, and leaked fluids accumulate over months and years. That buildup traps heat, hides leaks, and makes your engine bay look neglected when you pop the hood for any reason.
+          Most people never think about what's under the hood until something goes wrong. Grease, road grime, dirt, and leaked fluids accumulate over months and years. That buildup traps heat, hides leaks, and makes your engine bay look neglected when you pop the hood for any reason. Engine bay detailing is the part of car detailing most owners skip — and the one that pays back fastest at resale.
         </p>
         <p class="text-gray-600 mb-4">
           In Fort Lauderdale, the combination of heat and humidity accelerates grime buildup. Salt air from the ocean corrodes exposed metal surfaces faster than in drier climates. A clean engine bay runs cooler, lasts longer, and gives you peace of mind.
         </p>
         <p class="text-gray-600">
-          Route95 brings professional engine bay cleaning directly to your Fort Lauderdale location. We use automotive-specific degreasers and low-pressure rinsing to safely clean your engine bay without damaging sensitive electrical components.
+          Route95 is a mobile car detailing service that brings professional engine bay cleaning directly to your Fort Lauderdale location. As a fully mobile service, we come to your home or office with degreasers, brushes, and protectants — no need to drive anywhere or wait in a shop. We use automotive-specific degreasers and low-pressure rinsing to safely clean your engine bay without damaging sensitive electrical components.
         </p>
       </section>
 
@@ -113,9 +121,9 @@ const schemas = [serviceSchema, faqSchema];
       </section>
 
       <section>
-        <h2 class="text-2xl font-bold text-[#0f2a4a] mb-4">Why Clean Your Engine Bay?</h2>
+        <h2 class="text-2xl font-bold text-[#0f2a4a] mb-4">Is It Worth Getting Your Engine Bay Cleaned?</h2>
         <p class="text-gray-600 mb-4">
-          <strong>A clean engine bay makes it easier to spot leaks, improves resale value, and shows buyers or mechanics the vehicle has been well maintained.</strong>
+          <strong>Yes — getting your engine bay cleaned is worth it for three reasons: it makes leaks easier to spot, it improves resale value, and it shows buyers or mechanics the vehicle has been well maintained.</strong>
         </p>
         <p class="text-gray-600 mb-4">Benefits of engine bay cleaning:</p>
         <ul class="list-disc list-inside text-gray-600 mb-4 space-y-2">
@@ -127,6 +135,16 @@ const schemas = [serviceSchema, faqSchema];
         </ul>
         <p class="text-gray-600">
           If you're selling your car in Fort Lauderdale's competitive used car market, a clean engine bay signals careful ownership. Buyers and dealers notice.
+        </p>
+      </section>
+
+      <section>
+        <h2 class="text-2xl font-bold text-[#0f2a4a] mb-4">Can You Get an Engine Bay Cleaned at Home?</h2>
+        <p class="text-gray-600 mb-4">
+          <strong>Yes — Route95's mobile detailing service comes to your driveway in Fort Lauderdale and cleans the engine bay on-site. The mobile setup is identical to a shop: same degreasers, same brushes, same low-pressure rinsing. The only difference is we come to you, which saves you the trip and the wait.</strong>
+        </p>
+        <p class="text-gray-600">
+          Our mobile service handles the full engine bay detailing process — covering electronics, applying degreaser, agitating, low-pressure rinse, drying, and dressing — in the same 45 minutes a shop would take. We bring water, equipment, and products. You park the car and we handle the rest.
         </p>
       </section>
 


### PR DESCRIPTION
## Summary

Three surgical edits to `/engine-bay-cleaning-fort-lauderdale/` based on NW analysis (query `fc42e622f62bd07a`):

- **P1 — Term coverage**: intro reworked to include "engine bay detailing", "car detailing", "mobile car detailing service", "mobile service". Top competitor terms were missing despite the page being mobile-service-positioned.
- **P2 — New PAA capsule**: added H2 "Can You Get an Engine Bay Cleaned at Home?" (40–60 word bold answer + supporting paragraph) targeting the exact Google PAA. Matching `FAQPage` schema entry.
- **P3 — H2 reword**: "Why Clean Your Engine Bay?" → "Is It Worth Getting Your Engine Bay Cleaned?" — exact-match PAA phrasing. Bold answer block leads with "Yes" since the question is now yes/no. Matching `FAQPage` schema entry updated.

## Why

NW analysis showed:
- Baseline content score: **58**
- Top competitor: 60 (the SERP ceiling is genuinely low)
- Realistic post-edit target: **65–70** → clear semantic leader of the SERP

Page was already at NW target word count (536) and structurally sound — gaps were specifically term coverage and one missing PAA, not bloat. Edits add ~150 words.

Different from the upholstery page (NW score 90 → already top of class — left alone).

## Compliance (Auto Services / Florida)

- ✅ No "#1" / "best" / "guaranteed" language
- ✅ Pricing $75–$150 disclosed in offer schema before page
- ✅ Mobile-vs-shop comparison is factual ("we come to you", "saves the trip and wait"), no superiority claim
- ✅ Schema-content parity: every FAQ Q&A renders in body HTML

## Test plan

- [x] `npm run build` passes locally — 96 pages, both new FAQ schema entries render
- [ ] Cloudflare Pages preview deploys
- [ ] Re-score HTML against query `fc42e622f62bd07a` — expect 58 → 65+
- [ ] Verify all 4 H2 capsules render correctly (no layout regression)
- [ ] After merge, GSC URL inspection on `/engine-bay-cleaning-fort-lauderdale/` to nudge re-crawl

🤖 Generated with [Claude Code](https://claude.com/claude-code)