### PR TITLE
Apply WebPage schema + dates pattern to upholstery page (EN + ES)

### DIFF
--- a/src/pages/auto-upholstery-cleaning-fort-lauderdale.astro
+++ b/src/pages/auto-upholstery-cleaning-fort-lauderdale.astro
@@ -11,7 +11,25 @@ const whatsappUrl = `https://wa.me/${whatsappNumber}?text=${encodeURIComponent(w
 const title = "Auto Upholstery Cleaning Fort Lauderdale | Route95";
 const description = "Mobile auto upholstery cleaning in Fort Lauderdale. Fabric seats, leather, carpets deep cleaned on-site. Same-day available. Call 754-215-2272.";
 
+const datePublished = "2026-04-08";
+const dateModified = "2026-05-08";
+
 const siteUrl = "https://route95mobilecardetailing.com";
+
+const webPageSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "@id": `${siteUrl}/auto-upholstery-cleaning-fort-lauderdale/#webpage`,
+  "url": `${siteUrl}/auto-upholstery-cleaning-fort-lauderdale/`,
+  "name": title,
+  "description": description,
+  "inLanguage": "en-US",
+  "isPartOf": { "@id": `${siteUrl}/#website` },
+  "mainEntity": { "@id": `${siteUrl}/auto-upholstery-cleaning-fort-lauderdale/#service` },
+  "datePublished": datePublished,
+  "dateModified": dateModified
+};
+
 const categorySchema = {
   "@context": "https://schema.org",
   "@type": "Service",
@@ -118,7 +136,7 @@ const breadcrumbSchema = {
 };
 ---
 
-<BaseLayout title={title} description={description} currentPage="/auto-upholstery-cleaning-fort-lauderdale/" schema={[categorySchema, faqSchema, breadcrumbSchema]}>
+<BaseLayout title={title} description={description} currentPage="/auto-upholstery-cleaning-fort-lauderdale/" schema={[webPageSchema, categorySchema, faqSchema, breadcrumbSchema]}>
   <!-- Hero Section -->
   <section class="bg-gradient-to-br from-[#0c2448] to-[#1a5ca0] text-white py-16 lg:py-20">
     <div class="max-w-7xl mx-auto px-4">
@@ -155,6 +173,10 @@ const breadcrumbSchema = {
   <!-- FAQ Content Capsules -->
   <section class="py-12 lg:py-16">
     <div class="max-w-4xl mx-auto px-4 space-y-12">
+
+      <p class="text-sm text-gray-500 -mt-4">
+        <time datetime={dateModified}>Last updated May 8, 2026</time>
+      </p>
 
       <!-- What Does Auto Upholstery Cleaning Include -->
       <div>

--- a/src/pages/es/limpieza-de-tapiceria-de-autos-fort-lauderdale.astro
+++ b/src/pages/es/limpieza-de-tapiceria-de-autos-fort-lauderdale.astro
@@ -12,7 +12,25 @@ const whatsappUrl = `https://wa.me/${whatsappNumber}?text=${encodeURIComponent(w
 const title = "Limpieza de Tapicería de Autos Fort Lauderdale | Route95";
 const description = "Limpieza de tapicería de autos a domicilio en Fort Lauderdale. Asientos, alfombras y cuero limpiados en sitio. Llama al 754-215-2272.";
 
+const datePublished = "2026-04-08";
+const dateModified = "2026-05-08";
+
 const siteUrl = "https://route95mobilecardetailing.com";
+
+const webPageSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "@id": `${siteUrl}/es/limpieza-de-tapiceria-de-autos-fort-lauderdale/#webpage`,
+  "url": `${siteUrl}/es/limpieza-de-tapiceria-de-autos-fort-lauderdale/`,
+  "name": title,
+  "description": description,
+  "inLanguage": "es-US",
+  "isPartOf": { "@id": `${siteUrl}/#website` },
+  "mainEntity": { "@id": `${siteUrl}/es/limpieza-de-tapiceria-de-autos-fort-lauderdale/#service` },
+  "datePublished": datePublished,
+  "dateModified": dateModified
+};
+
 const categorySchema = {
   "@context": "https://schema.org",
   "@type": "Service",
@@ -118,7 +136,7 @@ const breadcrumbSchema = {
 };
 ---
 
-<BaseLayout title={title} description={description} currentPage="/es/limpieza-de-tapiceria-de-autos-fort-lauderdale/" schema={[categorySchema, faqSchema, breadcrumbSchema]}>
+<BaseLayout title={title} description={description} currentPage="/es/limpieza-de-tapiceria-de-autos-fort-lauderdale/" schema={[webPageSchema, categorySchema, faqSchema, breadcrumbSchema]}>
   <!-- Hero Section -->
   <section class="bg-gradient-to-br from-[#0c2448] to-[#1a5ca0] text-white py-16 lg:py-20">
     <div class="max-w-7xl mx-auto px-4">
@@ -155,6 +173,10 @@ const breadcrumbSchema = {
   <!-- FAQ Content Capsules -->
   <section class="py-12 lg:py-16">
     <div class="max-w-4xl mx-auto px-4 space-y-12">
+
+      <p class="text-sm text-gray-500 -mt-4">
+        <time datetime={dateModified}>Última actualización: 8 de mayo de 2026</time>
+      </p>
 
       <!-- What Does Auto Upholstery Cleaning Include -->
       <div>


### PR DESCRIPTION
## Summary

Extends the WebPage + datePublished/dateModified + visible byline pattern from PR #67 (odor page) to `/auto-upholstery-cleaning-fort-lauderdale/` — Stage 1's #1 NW priority target.

## Why this page next

- **Strategic timing**: Google is currently reconsolidating signals from the legacy `/upholstery-cleaning-fort-lauderdale/` URL via the 301 shipped in PR #65. Adding the freshness signal at the canonical destination *right now* reinforces "this is the active page" while the index merge completes.
- **Highest-priority target**: combined post-consolidation demand 722 imp / SV 5,400 / NW score already 90 (top of SERP). Worth investing the small effort to give it every available signal.
- **Pattern already proven**: same pattern shipped 30 minutes ago on the odor page, no production issues.

## Changes per page (EN + ES)

- `WebPage` schema with `@id`, `mainEntity` → Service, `isPartOf` → site
- `datePublished: 2026-04-08` (from `git log --reverse` — commit 66cecd3 added the page to capture the GSC query cluster). Same date EN + ES (added together).
- `dateModified: 2026-05-08` (today)
- Visible "Last updated May 8, 2026" / "Última actualización: 8 de mayo de 2026" byline as semantic `<time datetime>` element, placed at the top of the FAQ Content Capsules section just below the hero
- `schemas` array updated to include `webPageSchema` first

**No content/copy changes** — pure schema and freshness signal. NW score (90) is preserved.

## Test plan

- [x] `npm run build` passes — 94 pages, both new schemas render in dist HTML, both bylines render
- [ ] Cloudflare Pages preview deploys
- [ ] Apex `curl -s https://route95mobilecardetailing.com/auto-upholstery-cleaning-fort-lauderdale/ | grep '"@type":"WebPage"'` returns 1 after merge
- [ ] NW re-score against query `2ff30cc119f465dc` — expect 90 unchanged (or +1-2 from schema-content parity bump)

## Follow-up status (not in this PR)

Roll out same pattern to remaining ~23 service pages. Now done: odor, upholstery (EN+ES each). Engine bay (`/engine-bay-cleaning-fort-lauderdale/`) is the next obvious candidate since it was also recently NW-optimized in PR #66.

🤖 Generated with [Claude Code](https://claude.com/claude-code)