### PR TITLE
Apply WebPage schema + dates pattern to engine bay page (EN + ES)

### DIFF
--- a/src/pages/engine-bay-cleaning-fort-lauderdale.astro
+++ b/src/pages/engine-bay-cleaning-fort-lauderdale.astro
@@ -11,7 +11,25 @@ const parentCategory = {
   title: "Car Wash Services"
 };
 
+const datePublished = "2026-02-02";
+const dateModified = "2026-05-08";
+
 const siteUrl = "https://route95mobilecardetailing.com";
+
+const webPageSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "@id": `${siteUrl}/engine-bay-cleaning-fort-lauderdale/#webpage`,
+  "url": `${siteUrl}/engine-bay-cleaning-fort-lauderdale/`,
+  "name": title,
+  "description": description,
+  "inLanguage": "en-US",
+  "isPartOf": { "@id": `${siteUrl}/#website` },
+  "mainEntity": { "@id": `${siteUrl}/engine-bay-cleaning-fort-lauderdale/#service` },
+  "datePublished": datePublished,
+  "dateModified": dateModified
+};
+
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",
@@ -74,7 +92,7 @@ const faqSchema = {
   ]
 };
 
-const schemas = [serviceSchema, faqSchema];
+const schemas = [webPageSchema, serviceSchema, faqSchema];
 ---
 
 <ServiceLayout
@@ -86,6 +104,10 @@ const schemas = [serviceSchema, faqSchema];
   parentCategory={parentCategory}
   schema={schemas}
 >
+  <p class="text-sm text-gray-500 mb-6">
+    <time datetime={dateModified}>Last updated May 8, 2026</time>
+  </p>
+
   <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
     <div class="lg:col-span-2 space-y-8">
       <section>

--- a/src/pages/es/limpieza-de-motor-fort-lauderdale.astro
+++ b/src/pages/es/limpieza-de-motor-fort-lauderdale.astro
@@ -12,7 +12,25 @@ const parentCategory = {
   title: "Servicios de Lavado"
 };
 
+const datePublished = "2026-02-17";
+const dateModified = "2026-05-08";
+
 const siteUrl = "https://route95mobilecardetailing.com";
+
+const webPageSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "@id": `${siteUrl}/es/limpieza-de-motor-fort-lauderdale/#webpage`,
+  "url": `${siteUrl}/es/limpieza-de-motor-fort-lauderdale/`,
+  "name": title,
+  "description": description,
+  "inLanguage": "es-US",
+  "isPartOf": { "@id": `${siteUrl}/#website` },
+  "mainEntity": { "@id": `${siteUrl}/es/limpieza-de-motor-fort-lauderdale/#service` },
+  "datePublished": datePublished,
+  "dateModified": dateModified
+};
+
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",
@@ -67,7 +85,7 @@ const faqSchema = {
   ]
 };
 
-const schemas = [serviceSchema, faqSchema];
+const schemas = [webPageSchema, serviceSchema, faqSchema];
 ---
 
 <ServiceLayout
@@ -79,6 +97,10 @@ const schemas = [serviceSchema, faqSchema];
   parentCategory={parentCategory}
   schema={schemas}
 >
+  <p class="text-sm text-gray-500 mb-6">
+    <time datetime={dateModified}>Última actualización: 8 de mayo de 2026</time>
+  </p>
+
   <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
     <div class="lg:col-span-2 space-y-8">
       <section>


### PR DESCRIPTION
## Summary

Extends the WebPage + datePublished/dateModified + visible byline pattern to `/engine-bay-cleaning-fort-lauderdale/` (EN + ES). Third page on the pattern after odor (PR #67) and upholstery (PR #68).

## Why this page next

- Recently NW-optimized in PR #66 (58 → 69, top of SERP). Adding the freshness signal completes AISO §4 dimension 5 (Freshness) alongside the Citability gains from PR #66.
- Same diff size as upholstery PR (+46/-2). Pattern is well-tested.

## Changes per page (EN + ES)

- `WebPage` schema with `@id`, `mainEntity` → Service, `isPartOf` → site
- `datePublished` EN: **2026-02-02** (commit 556fe69 — initial 28-page service rollout)
- `datePublished` ES: **2026-02-17** (commit 29ff698 — engine bay was added separately to the ES side along with the chrome-polishing removal)
- `dateModified`: 2026-05-08
- Visible byline as semantic `<time datetime>` element, placed at top of the slot below the hero
- `schemas` array updated to include `webPageSchema` first

**No content/copy changes**. NW score (69) preserved.

## Test plan

- [x] `npm run build` passes — 94 pages, both schemas + bylines render in dist HTML
- [ ] Cloudflare Pages preview deploys
- [ ] Apex `curl -s https://route95mobilecardetailing.com/engine-bay-cleaning-fort-lauderdale/ | grep '"@type":"WebPage"'` returns 1 after merge
- [ ] NW re-score against query `fc42e622f62bd07a` — expect 69 unchanged (or +1-2)

## Pattern rollout status

Now done: odor (PR #67), upholstery (PR #68 in flight), engine bay (this PR). 3 of ~25 service pages.

The pattern is now a stable template — the next sweep PR should be a single bulk pass over the remaining ~22 pages, since the EN datePublished is `2026-02-02` for all pages added in commit 556fe69 (the initial 28-page rollout) plus a few outliers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)