### PR TITLE
Odor page: "Smoke"-led title + sharper meta for CTR

### DIFF
--- a/src/pages/odor-removal-fort-lauderdale.astro
+++ b/src/pages/odor-removal-fort-lauderdale.astro
@@ -3,8 +3,8 @@ import ServiceLayout from '../layouts/ServiceLayout.astro';
 import ProcessSteps from '../components/ProcessSteps.astro';
 
 const base = import.meta.env.BASE_URL;
-const title = "Car Odor Removal Fort Lauderdale | Mobile Service | Route95";
-const description = "Car odor removal in Fort Lauderdale. Eliminates smoke, pet, mildew, and food odors at the source — not just covers them. Mobile service. Call 754-215-2272.";
+const title = "Smoke & Car Odor Removal Fort Lauderdale | Route95";
+const description = "Smoke, pet & mildew odor removal in Fort Lauderdale. Ozone treatment destroys odors at the source — not air freshener. Mobile, same-day. Call 754-215-2272.";
 
 const parentCategory = {
   href: `${base}interior-car-detailing-fort-lauderdale/`,


### PR DESCRIPTION
## Was & Warum

`/odor-removal-fort-lauderdale/` rankt schon stark, konvertiert aber nicht:
- `smoke odor removal fort lauderdale` — 73 Impr, **Pos 4,7**, 0 Clicks
- `odor removal fort lauderdale` — 50 Impr, **Pos 4,8**, 0 Clicks

Top von Seite 1, aber 0 Clicks = reines Snippet-/CTR-Problem, kein Ranking-Problem. Der impressionsstärkste Query („**smoke** odor removal") stand nicht im Title (nur „Car Odor Removal").

## Änderungen (nur Title + Meta, kein Content/Schema)
- **Title:** `Car Odor Removal Fort Lauderdale | Mobile Service | Route95` → `Smoke & Car Odor Removal Fort Lauderdale | Route95` (50 Zeichen)
  - „Smoke" nach vorne = exakter Match auf den High-Intent-Top-Query
  - `odor removal fort lauderdale` bleibt als String intakt → schützt das Pos-4,7-Ranking
- **Meta:** `… Eliminates smoke, pet, mildew … at the source. Mobile service.` → Ozon-/Permanent-Angle + „same-day" als stärkerer Klick-Hook (155 Zeichen)

## Risiko
Minimal — der rankende Term `odor removal fort lauderdale` bleibt wörtlich im Title; H1 und Body unverändert. Reversibel.

Build: ✓ `npm run build` grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)