### PR TITLE
Upholstery: 2 topic-gap capsules + FTC fix (NW 87->90)

### DIFF
--- a/src/pages/auto-upholstery-cleaning-fort-lauderdale.astro
+++ b/src/pages/auto-upholstery-cleaning-fort-lauderdale.astro
@@ -106,6 +106,22 @@ const faqSchema = {
         "@type": "Answer",
         "text": "Mobile auto upholstery cleaning delivers the same results as shop service because we bring professional-grade hot water extractors, steam cleaners, and Chemical Guys products directly to your location. The equipment and technique are identical — the only difference is we come to you in Fort Lauderdale, saving you the trip and wait time."
       }
+    },
+    {
+      "@type": "Question",
+      "name": "What's the Best Way to Clean Auto Upholstery?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "The best way to clean auto upholstery is hot water extraction combined with material-specific cleaners — oxygen-infused shampoo for cloth, pH-balanced cleaner for leather. Vacuum thoroughly first to lift loose sand and pet hair, pre-treat any marks, then extract. Dry brushing and air fresheners only mask the problem; extraction physically pulls soil out of the padding."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What Types of Car Upholstery Can Be Cleaned?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "We clean every common car upholstery material: cloth and woven seats, genuine and synthetic leather, vinyl, suede, and Alcantara. Each surface needs its own method — cloth gets oxygen-infused shampoo and extraction, leather gets a pH-balanced cleaner plus conditioning, and delicate suede or Alcantara needs a gentle low-moisture approach."
+      }
     }
   ]
 };
@@ -236,6 +252,28 @@ const breadcrumbSchema = {
         </p>
       </div>
 
+      <!-- Best Way -->
+      <div>
+        <h2 class="text-2xl font-bold text-[#0f2a4a] mb-4">What's the Best Way to Clean Auto Upholstery?</h2>
+        <p class="text-gray-700 mb-4">
+          <strong>The best way to clean auto upholstery is hot water extraction combined with material-specific cleaners — oxygen-infused shampoo for cloth, pH-balanced cleaner for leather. Vacuum thoroughly first to lift loose sand and pet hair, pre-treat any marks, then extract. Dry brushing and air fresheners only mask the problem; extraction physically pulls soil out of the padding.</strong>
+        </p>
+        <p class="text-gray-600 mb-4">
+          Professional extraction reaches moisture and grime that household vacuums and store-bought sprays leave behind. After cleaning, we speed-dry the seats so trapped moisture can't breed mildew — critical in a humid coastal climate. Light agitation with the correct brush for each material lifts embedded soil while protecting the surface finish.
+        </p>
+      </div>
+
+      <!-- Upholstery Types -->
+      <div>
+        <h2 class="text-2xl font-bold text-[#0f2a4a] mb-4">What Types of Car Upholstery Can Be Cleaned?</h2>
+        <p class="text-gray-700 mb-4">
+          <strong>We clean every common car upholstery material: cloth and woven seats, genuine and synthetic leather, vinyl, suede, and Alcantara. Each surface needs its own method — cloth gets oxygen-infused shampoo and extraction, leather gets a pH-balanced cleaner plus conditioning, and delicate suede or Alcantara needs a gentle low-moisture approach.</strong>
+        </p>
+        <p class="text-gray-600 mb-4">
+          Vehicle size matters too — a compact sedan, a three-row SUV, and a work truck each take different time and product volumes, which is why we quote per vehicle. Whatever the material or vehicle size, our mobile auto detailing setup carries the right tools for it, so nothing gets skipped or treated with the wrong chemistry.
+        </p>
+      </div>
+
     </div>
   </section>
 
@@ -315,7 +353,7 @@ const breadcrumbSchema = {
         <div>
           <h3 class="text-xl font-bold text-[#0f2a4a] mb-2">Pet Hair Removal</h3>
           <p class="text-gray-600 mb-2">
-            Thorough pet hair extraction from upholstered seats, carpets, and hard-to-reach crevices. We use specialized tools to remove embedded pet hair that regular vacuuming leaves behind. About 40% of our Fort Lauderdale clients need this service.
+            Thorough pet hair extraction from upholstered seats, carpets, and hard-to-reach crevices. We use specialized tools to remove embedded pet hair that regular vacuuming leaves behind — one of the most requested add-ons among our Broward County clients.
           </p>
           <a href={`${base}pet-hair-removal-fort-lauderdale/`} class="text-[#0f2a4a] font-medium hover:text-[#c0c7cf] transition-colors">
             Learn more about Pet Hair Removal Fort Lauderdale →


### PR DESCRIPTION
## Kontext

Beim Öffnen des NW-Projekts vom 8.5. zeigte sich: die Seite scort **schon 87/90** (Term Coverage 79%, Title 86%). Sie wurde bei Erstellung (8. April) gut geschrieben — **kein Optimierungs-Rückstand**, anders als zunächst vermutet. Der Mai-Commit (#68) war reines Schema/dates.

## Änderungen (echte Content-Lücken, kein Score-Gaming)

**Topic Coverage 59% → schließt die zwei verbleibenden Lücken:**
- **„What's the Best Way to Clean Auto Upholstery?"** — war 0% (keine Überschrift)
- **„What Types of Car Upholstery Can Be Cleaned?"** — war 30% (deckt cloth/leather/vinyl/suede/Alcantara + vehicle size/SUV)

Beide matchen echte PAA-/Google-Suggest-Fragen aus dem NW-Brief. FAQPage-Schema synchron (5 → 7 Q&A, ≤10).

**Compliance:** unverifizierbare „40% of clients"-Statistik → nicht-numerische Formulierung (FTC-Substantiierung). Nebenbei fehlenden Local-Term `Broward County` ergänzt.

## Ehrliche Einordnung
87→90 ist On-Page-Feinschliff und wird das **Pos-~25-Ranking kaum bewegen**. Die Decke ist off-page: Seitenalter + interne Verlinkung, und die generischen National-Queries („auto upholstery cleaning", Pos 35+) sind für eine junge Local-Seite inhärent schwer. Diese 2 Kapseln sind trotzdem guter User-Content — deshalb drin.

Build: ✓ `npm run build` grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)