### PR TITLE
Align area-page prices with the canonical price table

### DIFF
--- a/src/pages/es/detallado-movil-dania-beach.astro
+++ b/src/pages/es/detallado-movil-dania-beach.astro
@@ -51,7 +51,7 @@ const faqSchema = {
       "name": "¿Cuánto cuesta el detallado de autos a domicilio en Dania Beach?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "El detallado de autos a domicilio en Dania Beach comienza desde $50 por un Lavado Rápido y hasta $460 por una Renovación Premium, dependiendo del tamaño del vehículo y el paquete seleccionado. Llama al 754-215-2272 para una cotización exacta."
+        "text": "El detallado de autos a domicilio en Dania Beach comienza desde $40 por un Lavado Rápido y hasta $460 por una Renovación Premium, dependiendo del tamaño del vehículo y el paquete seleccionado. Llama al 754-215-2272 para una cotización exacta."
       }
     },
     {
@@ -78,7 +78,7 @@ const schemas = [serviceSchema, faqSchema];
 const services = [
   { title: "Servicios de Lavado", description: "Lavado a mano, encerado, barra de arcilla, limpieza de rines, eliminación de manchas de agua y más.", href: localizedUrl('es', 'car-wash-fort-lauderdale') },
   { title: "Detallado Interior", description: "Lavado de asientos, limpieza y acondicionamiento de cuero, lavado de alfombras, limpieza a vapor.", href: localizedUrl('es', 'interior-car-detailing-fort-lauderdale') },
-  { title: "Paquetes de Detallado", description: "Lavado Rápido, Nuevo Comienzo, Limpieza Completa y Renovación Premium desde $50.", href: localizedUrl('es', 'car-detailing-services-fort-lauderdale') }
+  { title: "Paquetes de Detallado", description: "Lavado Rápido, Nuevo Comienzo, Limpieza Completa y Renovación Premium desde $40.", href: localizedUrl('es', 'car-detailing-services-fort-lauderdale') }
 ];
 
 const popularServices = [
@@ -91,9 +91,9 @@ const popularServices = [
 ];
 
 const packages = [
-  { name: "Lavado Rápido", price: "$50-$80", description: "Lavado a mano, limpieza de llantas y rines, limpieza de ventanas, limpieza interior, aspirado" },
+  { name: "Lavado Rápido", price: "$40-$60", description: "Lavado a mano, limpieza de llantas y rines, limpieza de ventanas, limpieza interior, aspirado" },
   { name: "Nuevo Comienzo", price: "$80-$110", description: "Lavado Rápido más acondicionador de llantas, tablero, consola central" },
-  { name: "Limpieza Completa", price: "$130-$160", description: "Nuevo Comienzo más guardabarros, alfombras, aspirado de cajuela" },
+  { name: "Limpieza Completa", price: "$140-$170", description: "Nuevo Comienzo más guardabarros, alfombras, aspirado de cajuela" },
   { name: "Renovación Premium", price: "$400-$460", description: "Limpieza Completa más shampoo interior, marcos de puertas, limpieza a vapor" }
 ];
 ---
@@ -159,7 +159,7 @@ const packages = [
             <div class="space-y-4">
               <div class="bg-gray-50 rounded-lg p-4">
                 <h3 class="font-bold text-[#0f2a4a] mb-2">¿Cuánto cuesta el detallado de autos a domicilio en Dania Beach?</h3>
-                <p class="text-gray-600">El detallado a domicilio en Dania Beach comienza desde $50 por un Lavado Rápido y hasta $460 por una Renovación Premium, dependiendo del tamaño del vehículo y el paquete. Llama al 754-215-2272 para una cotización exacta.</p>
+                <p class="text-gray-600">El detallado a domicilio en Dania Beach comienza desde $40 por un Lavado Rápido y hasta $460 por una Renovación Premium, dependiendo del tamaño del vehículo y el paquete. Llama al 754-215-2272 para una cotización exacta.</p>
               </div>
               <div class="bg-gray-50 rounded-lg p-4">
                 <h3 class="font-bold text-[#0f2a4a] mb-2">¿Sirven toda el área de Dania Beach?</h3>

--- a/src/pages/es/detallado-movil-hollywood-fl.astro
+++ b/src/pages/es/detallado-movil-hollywood-fl.astro
@@ -51,7 +51,7 @@ const faqSchema = {
       "name": "¿Cuánto cuesta el detallado de autos a domicilio en Hollywood, FL?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "El detallado de autos a domicilio en Hollywood, FL comienza desde $50 por un Lavado Rápido y hasta $460 por una Renovación Premium, dependiendo del tamaño del vehículo y el paquete seleccionado. Llama al 754-215-2272 para una cotización exacta."
+        "text": "El detallado de autos a domicilio en Hollywood, FL comienza desde $40 por un Lavado Rápido y hasta $460 por una Renovación Premium, dependiendo del tamaño del vehículo y el paquete seleccionado. Llama al 754-215-2272 para una cotización exacta."
       }
     },
     {
@@ -78,7 +78,7 @@ const schemas = [serviceSchema, faqSchema];
 const services = [
   { title: "Servicios de Lavado", description: "Lavado a mano, encerado, barra de arcilla, limpieza de rines, eliminación de manchas de agua y más.", href: localizedUrl('es', 'car-wash-fort-lauderdale') },
   { title: "Detallado Interior", description: "Lavado de asientos, limpieza y acondicionamiento de cuero, lavado de alfombras, limpieza a vapor.", href: localizedUrl('es', 'interior-car-detailing-fort-lauderdale') },
-  { title: "Paquetes de Detallado", description: "Lavado Rápido, Nuevo Comienzo, Limpieza Completa y Renovación Premium desde $50.", href: localizedUrl('es', 'car-detailing-services-fort-lauderdale') }
+  { title: "Paquetes de Detallado", description: "Lavado Rápido, Nuevo Comienzo, Limpieza Completa y Renovación Premium desde $40.", href: localizedUrl('es', 'car-detailing-services-fort-lauderdale') }
 ];
 
 const popularServices = [
@@ -91,9 +91,9 @@ const popularServices = [
 ];
 
 const packages = [
-  { name: "Lavado Rápido", price: "$50-$80", description: "Lavado a mano, limpieza de llantas y rines, limpieza de ventanas, limpieza interior, aspirado" },
+  { name: "Lavado Rápido", price: "$40-$60", description: "Lavado a mano, limpieza de llantas y rines, limpieza de ventanas, limpieza interior, aspirado" },
   { name: "Nuevo Comienzo", price: "$80-$110", description: "Lavado Rápido más acondicionador de llantas, tablero, consola central" },
-  { name: "Limpieza Completa", price: "$130-$160", description: "Nuevo Comienzo más guardabarros, alfombras, aspirado de cajuela" },
+  { name: "Limpieza Completa", price: "$140-$170", description: "Nuevo Comienzo más guardabarros, alfombras, aspirado de cajuela" },
   { name: "Renovación Premium", price: "$400-$460", description: "Limpieza Completa más shampoo interior, marcos de puertas, limpieza a vapor" }
 ];
 ---
@@ -159,7 +159,7 @@ const packages = [
             <div class="space-y-4">
               <div class="bg-gray-50 rounded-lg p-4">
                 <h3 class="font-bold text-[#0f2a4a] mb-2">¿Cuánto cuesta el detallado a domicilio en Hollywood, FL?</h3>
-                <p class="text-gray-600">El detallado a domicilio en Hollywood comienza desde $50 por un Lavado Rápido y hasta $460 por una Renovación Premium, dependiendo del tamaño del vehículo y el paquete. Llama al 754-215-2272 para una cotización exacta.</p>
+                <p class="text-gray-600">El detallado a domicilio en Hollywood comienza desde $40 por un Lavado Rápido y hasta $460 por una Renovación Premium, dependiendo del tamaño del vehículo y el paquete. Llama al 754-215-2272 para una cotización exacta.</p>
               </div>
               <div class="bg-gray-50 rounded-lg p-4">
                 <h3 class="font-bold text-[#0f2a4a] mb-2">¿Sirven toda el área de Hollywood, Florida?</h3>

--- a/src/pages/es/detallado-movil-pompano-beach.astro
+++ b/src/pages/es/detallado-movil-pompano-beach.astro
@@ -51,7 +51,7 @@ const faqSchema = {
       "name": "¿Cuánto cuesta el detallado de autos a domicilio en Pompano Beach?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "El detallado de autos a domicilio en Pompano Beach comienza desde $50 por un Lavado Rápido y hasta $460 por una Renovación Premium, dependiendo del tamaño del vehículo y el paquete seleccionado. Llama al 754-215-2272 para una cotización exacta."
+        "text": "El detallado de autos a domicilio en Pompano Beach comienza desde $40 por un Lavado Rápido y hasta $460 por una Renovación Premium, dependiendo del tamaño del vehículo y el paquete seleccionado. Llama al 754-215-2272 para una cotización exacta."
       }
     },
     {
@@ -78,7 +78,7 @@ const schemas = [serviceSchema, faqSchema];
 const services = [
   { title: "Servicios de Lavado", description: "Lavado a mano, encerado, barra de arcilla, limpieza de rines, eliminación de manchas de agua y más.", href: localizedUrl('es', 'car-wash-fort-lauderdale') },
   { title: "Detallado Interior", description: "Lavado de asientos, limpieza y acondicionamiento de cuero, lavado de alfombras, limpieza a vapor.", href: localizedUrl('es', 'interior-car-detailing-fort-lauderdale') },
-  { title: "Paquetes de Detallado", description: "Lavado Rápido, Nuevo Comienzo, Limpieza Completa y Renovación Premium desde $50.", href: localizedUrl('es', 'car-detailing-services-fort-lauderdale') }
+  { title: "Paquetes de Detallado", description: "Lavado Rápido, Nuevo Comienzo, Limpieza Completa y Renovación Premium desde $40.", href: localizedUrl('es', 'car-detailing-services-fort-lauderdale') }
 ];
 
 const popularServices = [
@@ -91,9 +91,9 @@ const popularServices = [
 ];
 
 const packages = [
-  { name: "Lavado Rápido", price: "$50-$80", description: "Lavado a mano, limpieza de llantas y rines, limpieza de ventanas, limpieza interior, aspirado" },
+  { name: "Lavado Rápido", price: "$40-$60", description: "Lavado a mano, limpieza de llantas y rines, limpieza de ventanas, limpieza interior, aspirado" },
   { name: "Nuevo Comienzo", price: "$80-$110", description: "Lavado Rápido más acondicionador de llantas, tablero, consola central" },
-  { name: "Limpieza Completa", price: "$130-$160", description: "Nuevo Comienzo más guardabarros, alfombras, aspirado de cajuela" },
+  { name: "Limpieza Completa", price: "$140-$170", description: "Nuevo Comienzo más guardabarros, alfombras, aspirado de cajuela" },
   { name: "Renovación Premium", price: "$400-$460", description: "Limpieza Completa más shampoo interior, marcos de puertas, limpieza a vapor" }
 ];
 ---
@@ -159,7 +159,7 @@ const packages = [
             <div class="space-y-4">
               <div class="bg-gray-50 rounded-lg p-4">
                 <h3 class="font-bold text-[#0f2a4a] mb-2">¿Cuánto cuesta el detallado a domicilio en Pompano Beach?</h3>
-                <p class="text-gray-600">El detallado a domicilio en Pompano Beach comienza desde $50 por un Lavado Rápido y hasta $460 por una Renovación Premium, dependiendo del tamaño del vehículo y el paquete. Llama al 754-215-2272 para una cotización exacta.</p>
+                <p class="text-gray-600">El detallado a domicilio en Pompano Beach comienza desde $40 por un Lavado Rápido y hasta $460 por una Renovación Premium, dependiendo del tamaño del vehículo y el paquete. Llama al 754-215-2272 para una cotización exacta.</p>
               </div>
               <div class="bg-gray-50 rounded-lg p-4">
                 <h3 class="font-bold text-[#0f2a4a] mb-2">¿Sirven toda el área de Pompano Beach?</h3>

--- a/src/pages/es/precios-detallado-movil-fort-lauderdale.astro
+++ b/src/pages/es/precios-detallado-movil-fort-lauderdale.astro
@@ -91,7 +91,7 @@ const faqSchema = {
       "name": "¿Cómo Afecta el Tamaño del Vehículo a los Precios?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "El tamaño del vehículo afecta los precios en todos los paquetes. Los sedanes tienen el precio base, las SUVs y crossovers cuestan $15 más por paquete, y las camionetas o vehículos grandes cuestan $30 más. Por ejemplo, una Limpieza Completa es $130 para un sedán, $145 para una SUV y $160 para una camioneta."
+        "text": "El tamaño del vehículo afecta los precios en todos los paquetes. Los sedanes tienen el precio base, las SUVs y crossovers cuestan $15 más por paquete, y las camionetas o vehículos grandes cuestan $30 más. Por ejemplo, una Limpieza Completa es $140 para un sedán, $155 para una SUV y $170 para una camioneta."
       }
     }
   ]

--- a/src/pages/mobile-car-detailing-dania-beach.astro
+++ b/src/pages/mobile-car-detailing-dania-beach.astro
@@ -50,7 +50,7 @@ const faqSchema = {
       "name": "How much does mobile car detailing cost in Dania Beach?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Mobile car detailing in Dania Beach starts at $50 for a Quick Wash and ranges up to $460 for a Premium Refresh, depending on vehicle size and package selected. Call 754-215-2272 for an exact quote."
+        "text": "Mobile car detailing in Dania Beach starts at $40 for a Quick Wash and ranges up to $460 for a Premium Refresh, depending on vehicle size and package selected. Call 754-215-2272 for an exact quote."
       }
     },
     {
@@ -77,7 +77,7 @@ const schemas = [serviceSchema, faqSchema];
 const services = [
   { title: "Car Wash Services", description: "Hand wash, waxing, clay bar treatment, wheel cleaning, water spot removal, and more.", href: `${base}car-wash-fort-lauderdale/` },
   { title: "Interior Car Detailing", description: "Seat shampooing, leather cleaning & conditioning, carpet cleaning, steam cleaning, odor removal.", href: `${base}interior-car-detailing-fort-lauderdale/` },
-  { title: "Detailing Packages", description: "Quick Wash, Fresh Start, Complete Clean & Premium Refresh packages starting at $50.", href: `${base}car-detailing-services-fort-lauderdale/` }
+  { title: "Detailing Packages", description: "Quick Wash, Fresh Start, Complete Clean & Premium Refresh packages starting at $40.", href: `${base}car-detailing-services-fort-lauderdale/` }
 ];
 
 const popularServices = [
@@ -90,9 +90,9 @@ const popularServices = [
 ];
 
 const packages = [
-  { name: "Quick Wash", price: "$50-$80", description: "Hand wash, tire & rim cleaning, window cleaning, interior wipe down, vacuum" },
+  { name: "Quick Wash", price: "$40-$60", description: "Hand wash, tire & rim cleaning, window cleaning, interior wipe down, vacuum" },
   { name: "Fresh Start", price: "$80-$110", description: "Quick Wash plus tire dressing, dashboard, center console cleaning" },
-  { name: "Complete Clean", price: "$130-$160", description: "Fresh Start plus fender wells, floor mats, trunk vacuum" },
+  { name: "Complete Clean", price: "$140-$170", description: "Fresh Start plus fender wells, floor mats, trunk vacuum" },
   { name: "Premium Refresh", price: "$400-$460", description: "Complete Clean plus interior shampoo, door jambs, steam cleaning" }
 ];
 ---
@@ -158,7 +158,7 @@ const packages = [
             <div class="space-y-4">
               <div class="bg-gray-50 rounded-lg p-4">
                 <h3 class="font-bold text-[#0f2a4a] mb-2">How much does mobile car detailing cost in Dania Beach?</h3>
-                <p class="text-gray-600">Mobile car detailing in Dania Beach starts at $50 for a Quick Wash and ranges up to $460 for a Premium Refresh, depending on vehicle size and package selected. Call 754-215-2272 for an exact quote.</p>
+                <p class="text-gray-600">Mobile car detailing in Dania Beach starts at $40 for a Quick Wash and ranges up to $460 for a Premium Refresh, depending on vehicle size and package selected. Call 754-215-2272 for an exact quote.</p>
               </div>
               <div class="bg-gray-50 rounded-lg p-4">
                 <h3 class="font-bold text-[#0f2a4a] mb-2">Do you serve all of Dania Beach?</h3>

--- a/src/pages/mobile-car-detailing-hollywood-fl.astro
+++ b/src/pages/mobile-car-detailing-hollywood-fl.astro
@@ -50,7 +50,7 @@ const faqSchema = {
       "name": "How much does mobile car detailing cost in Hollywood, FL?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Mobile car detailing in Hollywood, FL starts at $50 for a Quick Wash and ranges up to $460 for a Premium Refresh, depending on vehicle size and package selected. Call 754-215-2272 for an exact quote."
+        "text": "Mobile car detailing in Hollywood, FL starts at $40 for a Quick Wash and ranges up to $460 for a Premium Refresh, depending on vehicle size and package selected. Call 754-215-2272 for an exact quote."
       }
     },
     {
@@ -77,7 +77,7 @@ const schemas = [serviceSchema, faqSchema];
 const services = [
   { title: "Car Wash Services", description: "Hand wash, waxing, clay bar treatment, wheel cleaning, water spot removal, and more.", href: `${base}car-wash-fort-lauderdale/` },
   { title: "Interior Car Detailing", description: "Seat shampooing, leather cleaning & conditioning, carpet cleaning, steam cleaning, odor removal.", href: `${base}interior-car-detailing-fort-lauderdale/` },
-  { title: "Detailing Packages", description: "Quick Wash, Fresh Start, Complete Clean & Premium Refresh packages starting at $50.", href: `${base}car-detailing-services-fort-lauderdale/` }
+  { title: "Detailing Packages", description: "Quick Wash, Fresh Start, Complete Clean & Premium Refresh packages starting at $40.", href: `${base}car-detailing-services-fort-lauderdale/` }
 ];
 
 const popularServices = [
@@ -90,9 +90,9 @@ const popularServices = [
 ];
 
 const packages = [
-  { name: "Quick Wash", price: "$50-$80", description: "Hand wash, tire & rim cleaning, window cleaning, interior wipe down, vacuum" },
+  { name: "Quick Wash", price: "$40-$60", description: "Hand wash, tire & rim cleaning, window cleaning, interior wipe down, vacuum" },
   { name: "Fresh Start", price: "$80-$110", description: "Quick Wash plus tire dressing, dashboard, center console cleaning" },
-  { name: "Complete Clean", price: "$130-$160", description: "Fresh Start plus fender wells, floor mats, trunk vacuum" },
+  { name: "Complete Clean", price: "$140-$170", description: "Fresh Start plus fender wells, floor mats, trunk vacuum" },
   { name: "Premium Refresh", price: "$400-$460", description: "Complete Clean plus interior shampoo, door jambs, steam cleaning" }
 ];
 ---
@@ -158,7 +158,7 @@ const packages = [
             <div class="space-y-4">
               <div class="bg-gray-50 rounded-lg p-4">
                 <h3 class="font-bold text-[#0f2a4a] mb-2">How much does mobile car detailing cost in Hollywood, FL?</h3>
-                <p class="text-gray-600">Mobile car detailing in Hollywood, FL starts at $50 for a Quick Wash and ranges up to $460 for a Premium Refresh, depending on vehicle size and package selected. Call 754-215-2272 for an exact quote.</p>
+                <p class="text-gray-600">Mobile car detailing in Hollywood, FL starts at $40 for a Quick Wash and ranges up to $460 for a Premium Refresh, depending on vehicle size and package selected. Call 754-215-2272 for an exact quote.</p>
               </div>
               <div class="bg-gray-50 rounded-lg p-4">
                 <h3 class="font-bold text-[#0f2a4a] mb-2">Do you serve all of Hollywood, Florida?</h3>

--- a/src/pages/mobile-car-detailing-pompano-beach.astro
+++ b/src/pages/mobile-car-detailing-pompano-beach.astro
@@ -50,7 +50,7 @@ const faqSchema = {
       "name": "How much does mobile car detailing cost in Pompano Beach?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Mobile car detailing in Pompano Beach starts at $50 for a Quick Wash and ranges up to $460 for a Premium Refresh, depending on vehicle size and package selected. Call 754-215-2272 for an exact quote."
+        "text": "Mobile car detailing in Pompano Beach starts at $40 for a Quick Wash and ranges up to $460 for a Premium Refresh, depending on vehicle size and package selected. Call 754-215-2272 for an exact quote."
       }
     },
     {
@@ -77,7 +77,7 @@ const schemas = [serviceSchema, faqSchema];
 const services = [
   { title: "Car Wash Services", description: "Hand wash, waxing, clay bar treatment, wheel cleaning, water spot removal, and more.", href: `${base}car-wash-fort-lauderdale/` },
   { title: "Interior Car Detailing", description: "Seat shampooing, leather cleaning & conditioning, carpet cleaning, steam cleaning, odor removal.", href: `${base}interior-car-detailing-fort-lauderdale/` },
-  { title: "Detailing Packages", description: "Quick Wash, Fresh Start, Complete Clean & Premium Refresh packages starting at $50.", href: `${base}car-detailing-services-fort-lauderdale/` }
+  { title: "Detailing Packages", description: "Quick Wash, Fresh Start, Complete Clean & Premium Refresh packages starting at $40.", href: `${base}car-detailing-services-fort-lauderdale/` }
 ];
 
 const popularServices = [
@@ -90,9 +90,9 @@ const popularServices = [
 ];
 
 const packages = [
-  { name: "Quick Wash", price: "$50-$80", description: "Hand wash, tire & rim cleaning, window cleaning, interior wipe down, vacuum" },
+  { name: "Quick Wash", price: "$40-$60", description: "Hand wash, tire & rim cleaning, window cleaning, interior wipe down, vacuum" },
   { name: "Fresh Start", price: "$80-$110", description: "Quick Wash plus tire dressing, dashboard, center console cleaning" },
-  { name: "Complete Clean", price: "$130-$160", description: "Fresh Start plus fender wells, floor mats, trunk vacuum" },
+  { name: "Complete Clean", price: "$140-$170", description: "Fresh Start plus fender wells, floor mats, trunk vacuum" },
   { name: "Premium Refresh", price: "$400-$460", description: "Complete Clean plus interior shampoo, door jambs, steam cleaning" }
 ];
 ---
@@ -158,7 +158,7 @@ const packages = [
             <div class="space-y-4">
               <div class="bg-gray-50 rounded-lg p-4">
                 <h3 class="font-bold text-[#0f2a4a] mb-2">How much does mobile car detailing cost in Pompano Beach?</h3>
-                <p class="text-gray-600">Mobile car detailing in Pompano Beach starts at $50 for a Quick Wash and ranges up to $460 for a Premium Refresh, depending on vehicle size and package selected. Call 754-215-2272 for an exact quote.</p>
+                <p class="text-gray-600">Mobile car detailing in Pompano Beach starts at $40 for a Quick Wash and ranges up to $460 for a Premium Refresh, depending on vehicle size and package selected. Call 754-215-2272 for an exact quote.</p>
               </div>
               <div class="bg-gray-50 rounded-lg p-4">
                 <h3 class="font-bold text-[#0f2a4a] mb-2">Do you serve all of Pompano Beach?</h3>

--- a/src/pages/mobile-car-detailing-prices-fort-lauderdale.astro
+++ b/src/pages/mobile-car-detailing-prices-fort-lauderdale.astro
@@ -91,7 +91,7 @@ const faqSchema = {
       "name": "How Does Vehicle Size Affect Detailing Prices?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Vehicle size affects pricing across all packages. Sedans are the base price, SUVs and crossovers cost $15 more per package, and trucks or large vehicles cost $30 more. For example, a Complete Clean is $130 for a sedan, $145 for an SUV, and $160 for a truck."
+        "text": "Vehicle size affects pricing across all packages. Sedans are the base price, SUVs and crossovers cost $15 more per package, and trucks or large vehicles cost $30 more. For example, a Complete Clean is $140 for a sedan, $155 for an SUV, and $170 for a truck."
       }
     }
   ]


### PR DESCRIPTION
## Why

The 6 area pages (Dania Beach, Hollywood, Pompano Beach — EN + ES) showed package prices that had drifted from the main pricing table, and the pricing page itself contained an internal contradiction.

## Changes

**Area pages (EN + ES):**

| Package | Was | Now (table) |
|---|---|---|
| Quick Wash | $50–$80 | **$40–$60** |
| Complete Clean | $130–$160 | **$140–$170** |
| "starts/starting at $50" | $50 | **$40** (Quick Wash sedan base) |

Fresh Start ($80–$110) and Premium Refresh ($400–$460) already matched — unchanged.

**Pricing pages (EN + ES):** the vehicle-size FAQ example said Complete Clean is **$130/$145/$160**, contradicting the table's **$140/$155/$170**. Updated the example to match the table (confirmed canonical). The +$15 SUV / +$30 truck surcharge logic stays consistent.

## Verification

- `npm run build` → green, 94 pages.
- Grep sweep confirms no remaining `$50–$80`, `$130–$160`, or "starts at $50" anywhere; other legitimate `$50` references (e.g. the Steam Cleaning add-on) left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)