### PR TITLE
Apply WebPage schema + dateModified to 5 ES "a domicilio" pages

### DIFF
--- a/src/pages/es/encerado-de-autos-fort-lauderdale.astro
+++ b/src/pages/es/encerado-de-autos-fort-lauderdale.astro
@@ -12,7 +12,23 @@ const parentCategory = {
   title: "Servicios de Lavado"
 };
 
+const datePublished = "2026-02-06";
+const dateModified = "2026-06-19";
+
 const siteUrl = "https://route95mobilecardetailing.com";
+const webPageSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "@id": `${siteUrl}/es/encerado-de-autos-fort-lauderdale/#webpage`,
+  "url": `${siteUrl}/es/encerado-de-autos-fort-lauderdale/`,
+  "name": title,
+  "description": description,
+  "inLanguage": "es-US",
+  "isPartOf": { "@id": `${siteUrl}/#website` },
+  "mainEntity": { "@id": `${siteUrl}/es/encerado-de-autos-fort-lauderdale/#service` },
+  "datePublished": datePublished,
+  "dateModified": dateModified
+};
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",
@@ -75,7 +91,7 @@ const faqSchema = {
   ]
 };
 
-const schemas = [serviceSchema, faqSchema];
+const schemas = [webPageSchema, serviceSchema, faqSchema];
 ---
 
 <ServiceLayout
@@ -87,6 +103,10 @@ const schemas = [serviceSchema, faqSchema];
   parentCategory={parentCategory}
   schema={schemas}
 >
+  <p class="text-sm text-gray-500 mb-6">
+    <time datetime={dateModified}>Última actualización: 19 de junio de 2026</time>
+  </p>
+
   <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
     <div class="lg:col-span-2 space-y-8">
       <section>

--- a/src/pages/es/lavado-a-mano-fort-lauderdale.astro
+++ b/src/pages/es/lavado-a-mano-fort-lauderdale.astro
@@ -14,7 +14,23 @@ const parentCategory = {
   title: "Servicios de Lavado"
 };
 
+const datePublished = "2026-02-06";
+const dateModified = "2026-06-19";
+
 const siteUrl = "https://route95mobilecardetailing.com";
+const webPageSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "@id": `${siteUrl}/es/lavado-a-mano-fort-lauderdale/#webpage`,
+  "url": `${siteUrl}/es/lavado-a-mano-fort-lauderdale/`,
+  "name": title,
+  "description": description,
+  "inLanguage": "es-US",
+  "isPartOf": { "@id": `${siteUrl}/#website` },
+  "mainEntity": { "@id": `${siteUrl}/es/lavado-a-mano-fort-lauderdale/#service` },
+  "datePublished": datePublished,
+  "dateModified": dateModified
+};
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",
@@ -83,7 +99,7 @@ const faqSchema = {
   ]
 };
 
-const schemas = [serviceSchema, faqSchema];
+const schemas = [webPageSchema, serviceSchema, faqSchema];
 ---
 
 <ServiceLayout
@@ -95,6 +111,10 @@ const schemas = [serviceSchema, faqSchema];
   parentCategory={parentCategory}
   schema={schemas}
 >
+  <p class="text-sm text-gray-500 mb-6">
+    <time datetime={dateModified}>Última actualización: 19 de junio de 2026</time>
+  </p>
+
   <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
     <div class="lg:col-span-2 space-y-8">
       <section>

--- a/src/pages/es/lavado-de-autos-fort-lauderdale.astro
+++ b/src/pages/es/lavado-de-autos-fort-lauderdale.astro
@@ -12,7 +12,23 @@ const whatsappUrl = `https://wa.me/${whatsappNumber}?text=${encodeURIComponent(w
 const title = "Lavado de Autos a Domicilio Fort Lauderdale | Route95";
 const description = "Lavado de autos a domicilio en Fort Lauderdale. Vamos a tu casa u oficina. Lavado a mano, encerado, barra de arcilla, limpieza de rines.";
 
+const datePublished = "2026-02-06";
+const dateModified = "2026-06-19";
+
 const siteUrl = "https://route95mobilecardetailing.com";
+const webPageSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "@id": `${siteUrl}/es/lavado-de-autos-fort-lauderdale/#webpage`,
+  "url": `${siteUrl}/es/lavado-de-autos-fort-lauderdale/`,
+  "name": title,
+  "description": description,
+  "inLanguage": "es-US",
+  "isPartOf": { "@id": `${siteUrl}/#website` },
+  "mainEntity": { "@id": `${siteUrl}/es/lavado-de-autos-fort-lauderdale/#service` },
+  "datePublished": datePublished,
+  "dateModified": dateModified
+};
 const categorySchema = {
   "@context": "https://schema.org",
   "@type": "Service",
@@ -125,7 +141,7 @@ const faqSchema = {
 };
 ---
 
-<BaseLayout title={title} description={description} currentPage="/es/lavado-de-autos-fort-lauderdale/" schema={[categorySchema, faqSchema]}>
+<BaseLayout title={title} description={description} currentPage="/es/lavado-de-autos-fort-lauderdale/" schema={[webPageSchema, categorySchema, faqSchema]}>
   <!-- Hero Section -->
   <section class="bg-gradient-to-br from-[#0c2448] to-[#1a5ca0] text-white py-16 lg:py-20">
     <div class="max-w-7xl mx-auto px-4">
@@ -162,6 +178,10 @@ const faqSchema = {
   <!-- Services Content -->
   <section class="py-12 lg:py-16">
     <div class="max-w-4xl mx-auto px-4 space-y-12">
+
+      <p class="text-sm text-gray-500">
+        <time datetime={dateModified}>Última actualización: 19 de junio de 2026</time>
+      </p>
 
       <!-- Pricing -->
       <div>

--- a/src/pages/es/lavado-rapido-fort-lauderdale.astro
+++ b/src/pages/es/lavado-rapido-fort-lauderdale.astro
@@ -12,7 +12,24 @@ const parentCategory = {
   title: "Servicios de Detallado"
 };
 
+const datePublished = "2026-02-06";
+const dateModified = "2026-06-19";
+
 const siteUrl = "https://route95mobilecardetailing.com";
+
+const webPageSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "@id": `${siteUrl}/es/lavado-rapido-fort-lauderdale/#webpage`,
+  "url": `${siteUrl}/es/lavado-rapido-fort-lauderdale/`,
+  "name": title,
+  "description": description,
+  "inLanguage": "es-US",
+  "isPartOf": { "@id": `${siteUrl}/#website` },
+  "mainEntity": { "@id": `${siteUrl}/es/lavado-rapido-fort-lauderdale/#service` },
+  "datePublished": datePublished,
+  "dateModified": dateModified
+};
 
 const serviceSchema = {
   "@context": "https://schema.org",
@@ -77,7 +94,7 @@ const faqSchema = {
   ]
 };
 
-const schemas = [serviceSchema, faqSchema];
+const schemas = [webPageSchema, serviceSchema, faqSchema];
 ---
 
 <ServiceLayout
@@ -89,6 +106,10 @@ const schemas = [serviceSchema, faqSchema];
   parentCategory={parentCategory}
   schema={schemas}
 >
+  <p class="text-sm text-gray-500 mb-6">
+    <time datetime={dateModified}>Última actualización: 19 de junio de 2026</time>
+  </p>
+
   <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
     <div class="lg:col-span-2 space-y-8">
       <section>

--- a/src/pages/es/precios-detallado-movil-fort-lauderdale.astro
+++ b/src/pages/es/precios-detallado-movil-fort-lauderdale.astro
@@ -5,7 +5,24 @@ import { localizedUrl } from '../../i18n/utils';
 const title = "Precios de Detallado Móvil a Domicilio Fort Lauderdale";
 const description = "Precios de detallado y lavado de autos a domicilio en Fort Lauderdale desde $40. Paquetes Lavado Rápido a Renovación Premium. Llama al 754-215-2272.";
 
+const datePublished = "2026-02-17";
+const dateModified = "2026-06-19";
+
 const siteUrl = "https://route95mobilecardetailing.com";
+
+const webPageSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "@id": `${siteUrl}/es/precios-detallado-movil-fort-lauderdale/#webpage`,
+  "url": `${siteUrl}/es/precios-detallado-movil-fort-lauderdale/`,
+  "name": title,
+  "description": description,
+  "inLanguage": "es-US",
+  "isPartOf": { "@id": `${siteUrl}/#website` },
+  "mainEntity": { "@id": `${siteUrl}/es/precios-detallado-movil-fort-lauderdale/#service` },
+  "datePublished": datePublished,
+  "dateModified": dateModified
+};
 
 const serviceSchema = {
   "@context": "https://schema.org",
@@ -106,7 +123,7 @@ const faqSchema = {
 };
 ---
 
-<BaseLayout title={title} description={description} currentPage="/es/precios-detallado-movil-fort-lauderdale/" schema={[serviceSchema, faqSchema]}>
+<BaseLayout title={title} description={description} currentPage="/es/precios-detallado-movil-fort-lauderdale/" schema={[webPageSchema, serviceSchema, faqSchema]}>
   <!-- Hero Section -->
   <section class="bg-gradient-to-br from-[#0c2448] to-[#1a5ca0] text-white py-16 lg:py-20">
     <div class="max-w-7xl mx-auto px-4">
@@ -129,6 +146,9 @@ const faqSchema = {
   <!-- ¿Cuánto Cuesta el Detallado Móvil de Autos en Fort Lauderdale? -->
   <section class="py-12 lg:py-16 bg-gray-50">
     <div class="max-w-4xl mx-auto px-4">
+      <p class="text-sm text-gray-500 mb-6">
+        <time datetime={dateModified}>Última actualización: 19 de junio de 2026</time>
+      </p>
       <h2 class="text-2xl font-bold text-[#0f2a4a] mb-4">¿Cuánto Cuesta el Detallado Móvil de Autos a Domicilio en Fort Lauderdale?</h2>
       <p class="text-gray-600 mb-4">
         <strong>El detallado y lavado de autos a domicilio en Fort Lauderdale comienza en $40 para un sedán con Lavado Rápido y sube hasta $170 para una camioneta con Limpieza Completa. Los precios varían según el nivel del paquete y el tamaño del vehículo, con sedanes al precio base.</strong>


### PR DESCRIPTION
## Why
While reviewing the "a domicilio" cluster work (#70/#75/#76/#77/#78), the update-date pattern was found missing on all 5 pages. Only 6 pages site-wide carried it (engine-bay, upholstery, odor + ES counterparts, from #67/#68/#69). Since these 5 pages were genuinely edited today, adding `dateModified=2026-06-19` is **accurate** and restores the freshness signal Google reads.

## Changes (per page, no content/price edits)
- `datePublished` (from each file's git first-commit date) + `dateModified = 2026-06-19` consts
- A **WebPage** schema node (`mainEntity` → the page's `#service`, `isPartOf` → `#website`), prepended to the schema array
- A visible `<time datetime>Última actualización: 19 de junio de 2026</time>` line, matching the existing ES wording on the dated pages

Pages: `lavado-de-autos`, `lavado-a-mano`, `lavado-rapido`, `precios-detallado-movil`, `encerado-de-autos`

## Verification
- Build passes (94 pages)
- Confirmed in `dist` on all 5: WebPage JSON-LD present, `dateModified` = 2026-06-19, visible "Última actualización" line rendered
- Schema matches visible content; `datePublished` reflects real publish dates (2026-02-06 / 2026-02-17)

🤖 Generated with [Claude Code](https://claude.com/claude-code)