### PR TITLE
Apply WebPage schema + dateModified to 5 EN counterpart pages

### DIFF
--- a/src/pages/car-wash-fort-lauderdale.astro
+++ b/src/pages/car-wash-fort-lauderdale.astro
@@ -11,7 +11,23 @@ const whatsappUrl = `https://wa.me/${whatsappNumber}?text=${encodeURIComponent(w
 const title = "Car Wash Fort Lauderdale | Mobile Service | Route95";
 const description = "Mobile car wash in Fort Lauderdale. Hand wash, waxing, clay bar & wheel cleaning at your location. Same-day available. Call 754-215-2272.";
 
+const datePublished = "2026-02-02";
+const dateModified = "2026-03-24";
+
 const siteUrl = "https://route95mobilecardetailing.com";
+const webPageSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "@id": `${siteUrl}/car-wash-fort-lauderdale/#webpage`,
+  "url": `${siteUrl}/car-wash-fort-lauderdale/`,
+  "name": title,
+  "description": description,
+  "inLanguage": "en-US",
+  "isPartOf": { "@id": `${siteUrl}/#website` },
+  "mainEntity": { "@id": `${siteUrl}/car-wash-fort-lauderdale/#service` },
+  "datePublished": datePublished,
+  "dateModified": dateModified
+};
 const categorySchema = {
   "@context": "https://schema.org",
   "@type": "Service",
@@ -92,7 +108,7 @@ const faqSchema = {
 };
 ---
 
-<BaseLayout title={title} description={description} currentPage="/car-wash-fort-lauderdale/" schema={[categorySchema, faqSchema]}>
+<BaseLayout title={title} description={description} currentPage="/car-wash-fort-lauderdale/" schema={[webPageSchema, categorySchema, faqSchema]}>
   <!-- Hero Section -->
   <section class="bg-gradient-to-br from-[#0c2448] to-[#1a5ca0] text-white py-16 lg:py-20">
     <div class="max-w-7xl mx-auto px-4">
@@ -129,6 +145,10 @@ const faqSchema = {
   <!-- Services Content -->
   <section class="py-12 lg:py-16">
     <div class="max-w-4xl mx-auto px-4 space-y-12">
+
+      <p class="text-sm text-gray-500">
+        <time datetime={dateModified}>Last updated March 24, 2026</time>
+      </p>
 
       <!-- Hand Wash -->
       <div>

--- a/src/pages/car-waxing-fort-lauderdale.astro
+++ b/src/pages/car-waxing-fort-lauderdale.astro
@@ -11,7 +11,23 @@ const parentCategory = {
   title: "Car Wash Services"
 };
 
+const datePublished = "2026-02-02";
+const dateModified = "2026-03-24";
+
 const siteUrl = "https://route95mobilecardetailing.com";
+const webPageSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "@id": `${siteUrl}/car-waxing-fort-lauderdale/#webpage`,
+  "url": `${siteUrl}/car-waxing-fort-lauderdale/`,
+  "name": title,
+  "description": description,
+  "inLanguage": "en-US",
+  "isPartOf": { "@id": `${siteUrl}/#website` },
+  "mainEntity": { "@id": `${siteUrl}/car-waxing-fort-lauderdale/#service` },
+  "datePublished": datePublished,
+  "dateModified": dateModified
+};
 const serviceSchema = {
   "@context": "https://schema.org",
   "@type": "Service",
@@ -66,7 +82,7 @@ const faqSchema = {
   ]
 };
 
-const schemas = [serviceSchema, faqSchema];
+const schemas = [webPageSchema, serviceSchema, faqSchema];
 ---
 
 <ServiceLayout
@@ -78,6 +94,10 @@ const schemas = [serviceSchema, faqSchema];
   parentCategory={parentCategory}
   schema={schemas}
 >
+  <p class="text-sm text-gray-500 mb-6">
+    <time datetime={dateModified}>Last updated March 24, 2026</time>
+  </p>
+
   <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
     <div class="lg:col-span-2 space-y-8">
       <section>

--- a/src/pages/hand-wash-fort-lauderdale.astro
+++ b/src/pages/hand-wash-fort-lauderdale.astro
@@ -12,8 +12,24 @@ const parentCategory = {
   title: "Car Wash Services"
 };
 
+const datePublished = "2026-02-02";
+const dateModified = "2026-04-07";
+
 const siteUrl = "https://route95mobilecardetailing.com";
 const handWashImageUrl = `${siteUrl}/route95-hand-wash-fort-lauderdale-microfiber-mitt.webp`;
+const webPageSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "@id": `${siteUrl}/hand-wash-fort-lauderdale/#webpage`,
+  "url": `${siteUrl}/hand-wash-fort-lauderdale/`,
+  "name": title,
+  "description": description,
+  "inLanguage": "en-US",
+  "isPartOf": { "@id": `${siteUrl}/#website` },
+  "mainEntity": { "@id": `${siteUrl}/hand-wash-fort-lauderdale/#service` },
+  "datePublished": datePublished,
+  "dateModified": dateModified
+};
 
 const serviceSchema = {
   "@context": "https://schema.org",
@@ -89,7 +105,7 @@ const faqSchema = {
   ]
 };
 
-const schemas = [serviceSchema, faqSchema, imageSchema];
+const schemas = [webPageSchema, serviceSchema, faqSchema, imageSchema];
 ---
 
 <ServiceLayout
@@ -101,6 +117,10 @@ const schemas = [serviceSchema, faqSchema, imageSchema];
   parentCategory={parentCategory}
   schema={schemas}
 >
+  <p class="text-sm text-gray-500 mb-6">
+    <time datetime={dateModified}>Last updated April 7, 2026</time>
+  </p>
+
   <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
     <div class="lg:col-span-2 space-y-8">
       <section>

--- a/src/pages/mobile-car-detailing-prices-fort-lauderdale.astro
+++ b/src/pages/mobile-car-detailing-prices-fort-lauderdale.astro
@@ -5,7 +5,24 @@ const base = import.meta.env.BASE_URL;
 const title = "Mobile Car Detailing Prices Fort Lauderdale | Route95";
 const description = "Car detailing prices in Fort Lauderdale from $40. Quick Wash, Fresh Start, Complete Clean & Premium Refresh packages. Call 754-215-2272.";
 
+const datePublished = "2026-02-17";
+const dateModified = "2026-06-18";
+
 const siteUrl = "https://route95mobilecardetailing.com";
+
+const webPageSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "@id": `${siteUrl}/mobile-car-detailing-prices-fort-lauderdale/#webpage`,
+  "url": `${siteUrl}/mobile-car-detailing-prices-fort-lauderdale/`,
+  "name": title,
+  "description": description,
+  "inLanguage": "en-US",
+  "isPartOf": { "@id": `${siteUrl}/#website` },
+  "mainEntity": { "@id": `${siteUrl}/mobile-car-detailing-prices-fort-lauderdale/#service` },
+  "datePublished": datePublished,
+  "dateModified": dateModified
+};
 
 const serviceSchema = {
   "@context": "https://schema.org",
@@ -98,7 +115,7 @@ const faqSchema = {
 };
 ---
 
-<BaseLayout title={title} description={description} currentPage="/mobile-car-detailing-prices-fort-lauderdale/" schema={[serviceSchema, faqSchema]}>
+<BaseLayout title={title} description={description} currentPage="/mobile-car-detailing-prices-fort-lauderdale/" schema={[webPageSchema, serviceSchema, faqSchema]}>
   <!-- Hero Section -->
   <section class="bg-gradient-to-br from-[#0c2448] to-[#1a5ca0] text-white py-16 lg:py-20">
     <div class="max-w-7xl mx-auto px-4">
@@ -121,6 +138,9 @@ const faqSchema = {
   <!-- How Much Does Mobile Car Detailing Cost -->
   <section class="py-12 lg:py-16 bg-gray-50">
     <div class="max-w-4xl mx-auto px-4">
+      <p class="text-sm text-gray-500 mb-6">
+        <time datetime={dateModified}>Last updated June 18, 2026</time>
+      </p>
       <h2 class="text-2xl font-bold text-[#0f2a4a] mb-4">How Much Does Mobile Car Detailing Cost in Fort Lauderdale?</h2>
       <p class="text-gray-600 mb-4">
         <strong>Mobile car detailing in Fort Lauderdale starts at $40 for a sedan Quick Wash and goes up to $170 for a truck Complete Clean. Prices vary by package tier and vehicle size, with sedans at the base price.</strong>

--- a/src/pages/quick-wash-fort-lauderdale.astro
+++ b/src/pages/quick-wash-fort-lauderdale.astro
@@ -11,7 +11,24 @@ const parentCategory = {
   title: "Car Detailing Services"
 };
 
+const datePublished = "2026-02-05";
+const dateModified = "2026-03-31";
+
 const siteUrl = "https://route95mobilecardetailing.com";
+
+const webPageSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "@id": `${siteUrl}/quick-wash-fort-lauderdale/#webpage`,
+  "url": `${siteUrl}/quick-wash-fort-lauderdale/`,
+  "name": title,
+  "description": description,
+  "inLanguage": "en-US",
+  "isPartOf": { "@id": `${siteUrl}/#website` },
+  "mainEntity": { "@id": `${siteUrl}/quick-wash-fort-lauderdale/#service` },
+  "datePublished": datePublished,
+  "dateModified": dateModified
+};
 
 const serviceSchema = {
   "@context": "https://schema.org",
@@ -60,7 +77,7 @@ const faqSchema = {
   ]
 };
 
-const schemas = [serviceSchema, faqSchema];
+const schemas = [webPageSchema, serviceSchema, faqSchema];
 ---
 
 <ServiceLayout
@@ -72,6 +89,10 @@ const schemas = [serviceSchema, faqSchema];
   parentCategory={parentCategory}
   schema={schemas}
 >
+  <p class="text-sm text-gray-500 mb-6">
+    <time datetime={dateModified}>Last updated March 31, 2026</time>
+  </p>
+
   <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
     <div class="lg:col-span-2 space-y-8">
       <section>


### PR DESCRIPTION
## Why
EN↔ES parity for the update-date pattern. #79 added it to the 5 Spanish "a domicilio" cluster pages; this does their English counterparts (car-wash, hand-wash, quick-wash, car-waxing, mobile-car-detailing-prices).

## Dating approach — realistic, derived from git
Unlike the ES pages (genuinely edited today → `dateModified=2026-06-19`), these EN pages were **not** content-edited in this work. Claiming "updated today" would be misleading, so `dateModified` is each file's **last real content commit** from git:

| Page | datePublished | dateModified | last commit |
|---|---|---|---|
| car-wash | 2026-02-02 | 2026-03-24 | title/meta fix |
| hand-wash | 2026-02-02 | 2026-04-07 | schema add |
| quick-wash | 2026-02-05 | 2026-03-31 | exterior-only rewrite |
| car-waxing | 2026-02-02 | 2026-03-24 | title/meta fix |
| mobile-car-detailing-prices | 2026-02-17 | 2026-06-18 | price alignment (#74) |

## Changes (per page, no content/price edits)
- `datePublished` + `dateModified` consts, a **WebPage** schema node (`inLanguage: en-US`, `mainEntity` → page's `#service`) prepended to the schema array, and a visible `<time>Last updated …</time>` line matching the existing EN wording (engine-bay/upholstery/odor).

## Verification
- Build passes (94 pages)
- Confirmed in `dist` on all 5: WebPage JSON-LD present, correct `dateModified`, visible "Last updated" line rendered

🤖 Generated with [Claude Code](https://claude.com/claude-code)