### PR TITLE
Live availability slot picker for bookings (Phase 2)

### DIFF
--- a/functions/api/_google.js
+++ b/functions/api/_google.js
@@ -1,0 +1,79 @@
+// Shared Google service-account auth for the booking Functions.
+// Underscore-prefixed → not exposed as a route, only importable.
+//
+// Mints an OAuth2 access token from the service-account credentials in env
+// (GOOGLE_SA_EMAIL + GOOGLE_SA_PRIVATE_KEY) using a JWT bearer grant, signed
+// with the Web Crypto API (RS256). Returns null if creds are missing/invalid,
+// so callers degrade gracefully.
+
+export async function getAccessToken(env) {
+  const email = env.GOOGLE_SA_EMAIL;
+  const rawKey = env.GOOGLE_SA_PRIVATE_KEY;
+  if (!email || !rawKey) return null;
+  const pem = rawKey.replace(/\\n/g, "\n");
+
+  const now = Math.floor(Date.now() / 1000);
+  const header = { alg: "RS256", typ: "JWT" };
+  const claim = {
+    iss: email,
+    scope:
+      "https://www.googleapis.com/auth/calendar.events " +
+      "https://www.googleapis.com/auth/calendar.freebusy",
+    aud: "https://oauth2.googleapis.com/token",
+    iat: now,
+    exp: now + 3600,
+  };
+
+  const unsigned =
+    b64urlStr(JSON.stringify(header)) + "." + b64urlStr(JSON.stringify(claim));
+
+  const cryptoKey = await crypto.subtle.importKey(
+    "pkcs8",
+    pemToBuffer(pem),
+    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+    false,
+    ["sign"]
+  );
+  const sig = await crypto.subtle.sign(
+    "RSASSA-PKCS1-v1_5",
+    cryptoKey,
+    new TextEncoder().encode(unsigned)
+  );
+  const jwt = unsigned + "." + b64urlBytes(sig);
+
+  const res = await fetch("https://oauth2.googleapis.com/token", {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body:
+      "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=" +
+      encodeURIComponent(jwt),
+  });
+  if (!res.ok) return null;
+  const j = await res.json().catch(() => ({}));
+  return j.access_token || null;
+}
+
+function b64urlStr(s) {
+  return btoa(unescape(encodeURIComponent(s)))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+function b64urlBytes(buf) {
+  const arr = new Uint8Array(buf);
+  let bin = "";
+  for (let i = 0; i < arr.length; i++) bin += String.fromCharCode(arr[i]);
+  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function pemToBuffer(pem) {
+  const b64 = pem
+    .replace(/-----BEGIN [^-]+-----/, "")
+    .replace(/-----END [^-]+-----/, "")
+    .replace(/\s+/g, "");
+  const bin = atob(b64);
+  const buf = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) buf[i] = bin.charCodeAt(i);
+  return buf.buffer;
+}

--- a/functions/api/_time.js
+++ b/functions/api/_time.js
@@ -1,0 +1,44 @@
+// Shared timezone helpers for the booking Functions.
+// Underscore-prefixed → not a route, only importable.
+// All math is done against a named IANA zone so DST (EDT/EST) is handled
+// correctly without hardcoding offsets.
+
+// Offset in minutes of `timeZone` on the given local date (e.g. -240 EDT, -300 EST).
+export function tzOffsetMinutes(timeZone, dateStr) {
+  const noon = new Date(`${dateStr}T12:00:00Z`);
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    timeZoneName: "longOffset",
+  }).formatToParts(noon);
+  const tzName = parts.find((p) => p.type === "timeZoneName")?.value || "GMT+0";
+  const m = tzName.match(/GMT([+-])(\d{2}):?(\d{2})?/);
+  if (!m) return 0;
+  const sign = m[1] === "-" ? -1 : 1;
+  const h = parseInt(m[2], 10);
+  const min = parseInt(m[3] || "0", 10);
+  return sign * (h * 60 + min);
+}
+
+// Local "YYYY-MM-DD" + "HH:MM" → UTC epoch ms, given that day's offset.
+export function localToUtcMs(dateStr, hhmm, offsetMin) {
+  const [y, mo, d] = dateStr.split("-").map(Number);
+  const [h, mi] = hhmm.split(":").map(Number);
+  return Date.UTC(y, mo - 1, d, h, mi) - offsetMin * 60000;
+}
+
+// UTC epoch ms → local "HH:MM", given that day's offset.
+export function msToLocalHHMM(ms, offsetMin) {
+  const local = new Date(ms + offsetMin * 60000);
+  const h = String(local.getUTCHours()).padStart(2, "0");
+  const m = String(local.getUTCMinutes()).padStart(2, "0");
+  return `${h}:${m}`;
+}
+
+// "HH:MM" + minutes → "HH:MM" (same day; jobs never cross midnight here).
+export function addMinutes(hhmm, mins) {
+  const [h, mi] = hhmm.split(":").map(Number);
+  const total = h * 60 + mi + mins;
+  const hh = String(Math.floor(total / 60) % 24).padStart(2, "0");
+  const mm = String(total % 60).padStart(2, "0");
+  return `${hh}:${mm}`;
+}

--- a/functions/api/appointment.js
+++ b/functions/api/appointment.js
@@ -26,6 +26,7 @@ import {
   VEHICLES,
   serviceMinutes,
   labelOf,
+  validAddons,
   AVAILABILITY,
 } from "../../src/config/booking.mjs";
 import { getAccessToken } from "./_google.js";
@@ -51,7 +52,11 @@ export async function onRequestPost(context) {
   }
 
   const lang = body.lang === "es" ? "es" : "en";
-  const addonKeys = Array.isArray(body.addonKeys) ? body.addonKeys : [];
+  // Trust the server config, not the client: drop add-ons not offered with this service.
+  const addonKeys = validAddons(
+    body.serviceKey || "",
+    Array.isArray(body.addonKeys) ? body.addonKeys : []
+  );
   const data = {
     lang,
     name: body.name,

--- a/functions/api/appointment.js
+++ b/functions/api/appointment.js
@@ -1,55 +1,73 @@
 // Cloudflare Pages Function — POST /api/appointment
 //
-// Handles a booking request from BookingForm.astro. Two jobs per request:
+// Handles a booking from BookingForm.astro. Two jobs per request:
 //   1. EMAIL (must-succeed): forwards to Web3Forms so Gustavo always gets the
-//      notification at contact@route95mobilecardetailing.com — same as before.
+//      notification at contact@route95mobilecardetailing.com.
 //   2. CALENDAR (best-effort): creates a TENTATIVE event in Gustavo's Google
-//      Calendar (route95.cw@gmail.com) via the Google Calendar API, so every
-//      request also shows up on his phone. If the calendar step fails or the
-//      Google credentials aren't set yet, the email still goes out — no request
-//      is ever lost.
+//      Calendar via the Calendar API. If it fails or the Google creds aren't
+//      set, the email still goes out — no request is ever lost.
 //
-// Phase 1 (this file): customer picks a coarse time window (morning / afternoon
-// / late afternoon / flexible) → we drop a tentative block on that window.
-// Phase 2 (later): real slot picker driven by service duration + FreeBusy. The
-// helpers below (getAccessToken / createEvent) are reused as-is for that.
+// Time handling:
+//   • Phase 2 — customer picked an exact slot (data.startTime "HH:MM"): event
+//     spans [startTime, startTime + estimated duration].
+//   • Fallback — no slot (closed day / fully booked / availability API down):
+//     all-day tentative event flagged as "no time chosen".
 //
-// ── Required Cloudflare env vars (Settings → Environment variables) ──
-//   GOOGLE_SA_EMAIL        service-account email (…@….iam.gserviceaccount.com)
-//   GOOGLE_SA_PRIVATE_KEY  service-account private key (PEM; \n or real newlines)
-//   GOOGLE_CALENDAR_ID     route95.cw@gmail.com  (calendar shared w/ the SA,
-//                          permission "Make changes to events")
-//   WEB3FORMS_ACCESS_KEY   Web3Forms access key (optional; falls back to the
-//                          existing public key so email keeps working pre-setup)
+// Labels (service / add-ons / vehicle) are resolved server-side from stable
+// keys via src/config/booking.mjs, so they stay correct in EN and ES.
+//
+// ── Required Cloudflare env vars ──
+//   GOOGLE_SA_EMAIL, GOOGLE_SA_PRIVATE_KEY, GOOGLE_CALENDAR_ID,
+//   WEB3FORMS_ACCESS_KEY (optional; falls back to the existing public key).
 
-const TZ = "America/New_York";
+import {
+  SERVICES,
+  ADDONS,
+  VEHICLES,
+  serviceMinutes,
+  labelOf,
+  AVAILABILITY,
+} from "../../src/config/booking.mjs";
+import { getAccessToken } from "./_google.js";
+import { addMinutes } from "./_time.js";
 
-// Coarse time windows → [start, end] local clock times.
-const WINDOWS = {
-  morning: ["09:00:00", "12:00:00"],
-  afternoon: ["12:00:00", "15:00:00"],
-  late: ["15:00:00", "18:00:00"],
-  // "flexible" (and anything unknown) → all-day event, handled below.
-};
+const TZ = AVAILABILITY.timeZone;
 
 export async function onRequestPost(context) {
   const { request, env } = context;
 
-  let data;
+  let body;
   try {
-    data = await request.json();
+    body = await request.json();
   } catch {
     return json({ success: false, message: "Bad request" }, 400);
   }
 
   // Honeypot: a real user never checks this. Pretend success, do nothing.
-  if (data.botcheck) return json({ success: true });
+  if (body.botcheck) return json({ success: true });
 
-  if (!data.name || !data.phone || !data.address || !data.date) {
+  if (!body.name || !body.phone || !body.address || !body.date) {
     return json({ success: false, message: "Missing required fields" }, 422);
   }
 
-  // 1) Email — the reliable path. Awaited; its result decides overall success.
+  const lang = body.lang === "es" ? "es" : "en";
+  const addonKeys = Array.isArray(body.addonKeys) ? body.addonKeys : [];
+  const data = {
+    lang,
+    name: body.name,
+    phone: body.phone,
+    address: body.address,
+    date: body.date,
+    startTime: /^\d{2}:\d{2}$/.test(body.startTime || "") ? body.startTime : "",
+    notes: body.notes || "",
+    serviceKey: body.serviceKey || "",
+    serviceLabel: labelOf(SERVICES, body.serviceKey, lang) || "—",
+    vehicleLabel: labelOf(VEHICLES, body.vehicleKey, lang),
+    addonLabels: addonKeys.map((k) => labelOf(ADDONS, k, lang)).filter(Boolean),
+    minutes: serviceMinutes(body.serviceKey, addonKeys),
+  };
+
+  // 1) Email — reliable path. Awaited; its result decides overall success.
   let emailed = false;
   try {
     emailed = await sendEmail(env, data);
@@ -81,6 +99,10 @@ async function sendEmail(env, data) {
       ? "Nueva solicitud de cita — Route95"
       : "New appointment request — Route95";
 
+  const when = data.startTime
+    ? `${data.date} ${data.startTime}–${addMinutes(data.startTime, data.minutes)} (~${data.minutes} min)`
+    : `${data.date} (no specific time chosen)`;
+
   const payload = {
     access_key: key,
     subject,
@@ -88,14 +110,10 @@ async function sendEmail(env, data) {
     Name: data.name,
     Phone: data.phone,
     Address: data.address,
-    Service: data.serviceLabel || "—",
+    Service: data.serviceLabel,
     Vehicle: data.vehicleLabel || "—",
-    "Preferred date": data.date,
-    "Preferred time": data.timeLabel || "—",
-    "Add-ons":
-      Array.isArray(data.addons) && data.addons.length
-        ? data.addons.join(", ")
-        : "—",
+    When: when,
+    "Add-ons": data.addonLabels.length ? data.addonLabels.join(", ") : "—",
     Notes: data.notes || "—",
   };
 
@@ -119,28 +137,27 @@ async function createEvent(env, token, data) {
     `Name: ${data.name}`,
     `Phone: ${data.phone}`,
     `Address: ${data.address}`,
-    `Service: ${data.serviceLabel || "—"}`,
+    `Service: ${data.serviceLabel}`,
     data.vehicleLabel ? `Vehicle: ${data.vehicleLabel}` : null,
-    Array.isArray(data.addons) && data.addons.length
-      ? `Add-ons: ${data.addons.join(", ")}`
-      : null,
-    `Preferred time: ${data.timeLabel || "—"}`,
+    data.addonLabels.length ? `Add-ons: ${data.addonLabels.join(", ")}` : null,
+    `Estimated duration: ~${data.minutes} min`,
     data.notes ? `Notes: ${data.notes}` : null,
   ].filter(Boolean);
 
   const event = {
-    summary: `📋 REQUEST: ${data.serviceLabel || "Detail"} — ${data.name}`,
+    summary: `📋 REQUEST: ${data.serviceLabel} — ${data.name}`,
     location: data.address,
     description: descLines.join("\n"),
     status: "tentative",
   };
 
-  const win = WINDOWS[data.timeKey];
-  if (win) {
-    event.start = { dateTime: `${data.date}T${win[0]}`, timeZone: TZ };
-    event.end = { dateTime: `${data.date}T${win[1]}`, timeZone: TZ };
+  if (data.startTime) {
+    const end = addMinutes(data.startTime, data.minutes);
+    // dateTime without offset + explicit timeZone → Google resolves DST itself.
+    event.start = { dateTime: `${data.date}T${data.startTime}:00`, timeZone: TZ };
+    event.end = { dateTime: `${data.date}T${end}:00`, timeZone: TZ };
   } else {
-    // Flexible / unknown → all-day. All-day end date is exclusive.
+    // No slot chosen → all-day request. All-day end date is exclusive.
     event.start = { date: data.date };
     event.end = { date: nextDay(data.date) };
   }
@@ -161,53 +178,6 @@ async function createEvent(env, token, data) {
   return res.ok;
 }
 
-// ── Service-account OAuth2 (JWT bearer) → access token ──
-async function getAccessToken(env) {
-  const email = env.GOOGLE_SA_EMAIL;
-  const rawKey = env.GOOGLE_SA_PRIVATE_KEY;
-  if (!email || !rawKey) return null;
-  const pem = rawKey.replace(/\\n/g, "\n");
-
-  const now = Math.floor(Date.now() / 1000);
-  const header = { alg: "RS256", typ: "JWT" };
-  const claim = {
-    iss: email,
-    scope: "https://www.googleapis.com/auth/calendar.events",
-    aud: "https://oauth2.googleapis.com/token",
-    iat: now,
-    exp: now + 3600,
-  };
-
-  const unsigned =
-    b64urlStr(JSON.stringify(header)) + "." + b64urlStr(JSON.stringify(claim));
-
-  const cryptoKey = await crypto.subtle.importKey(
-    "pkcs8",
-    pemToBuffer(pem),
-    { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
-    false,
-    ["sign"]
-  );
-  const sig = await crypto.subtle.sign(
-    "RSASSA-PKCS1-v1_5",
-    cryptoKey,
-    new TextEncoder().encode(unsigned)
-  );
-  const jwt = unsigned + "." + b64urlBytes(sig);
-
-  const res = await fetch("https://oauth2.googleapis.com/token", {
-    method: "POST",
-    headers: { "content-type": "application/x-www-form-urlencoded" },
-    body:
-      "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=" +
-      encodeURIComponent(jwt),
-  });
-  if (!res.ok) return null;
-  const j = await res.json().catch(() => ({}));
-  return j.access_token || null;
-}
-
-// ── helpers ──
 function json(obj, status) {
   return new Response(JSON.stringify(obj), {
     status: status || 200,
@@ -219,29 +189,4 @@ function nextDay(d) {
   const dt = new Date(`${d}T00:00:00Z`);
   dt.setUTCDate(dt.getUTCDate() + 1);
   return dt.toISOString().slice(0, 10);
-}
-
-function b64urlStr(s) {
-  return btoa(unescape(encodeURIComponent(s)))
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/, "");
-}
-
-function b64urlBytes(buf) {
-  const arr = new Uint8Array(buf);
-  let bin = "";
-  for (let i = 0; i < arr.length; i++) bin += String.fromCharCode(arr[i]);
-  return btoa(bin).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-}
-
-function pemToBuffer(pem) {
-  const b64 = pem
-    .replace(/-----BEGIN [^-]+-----/, "")
-    .replace(/-----END [^-]+-----/, "")
-    .replace(/\s+/g, "");
-  const bin = atob(b64);
-  const buf = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; i++) buf[i] = bin.charCodeAt(i);
-  return buf.buffer;
 }

--- a/functions/api/availability.js
+++ b/functions/api/availability.js
@@ -10,7 +10,11 @@
 // On any backend failure it returns { ok:false } and the frontend falls back to
 // the Phase 1 "request a time window" flow — so the form always works.
 
-import { AVAILABILITY, serviceMinutes } from "../../src/config/booking.mjs";
+import {
+  AVAILABILITY,
+  serviceMinutes,
+  validAddons,
+} from "../../src/config/booking.mjs";
 import { getAccessToken } from "./_google.js";
 import { tzOffsetMinutes, localToUtcMs, msToLocalHHMM } from "./_time.js";
 
@@ -21,7 +25,7 @@ export async function onRequestGet(context) {
   const url = new URL(request.url);
   const date = url.searchParams.get("date"); // YYYY-MM-DD (local)
   const service = url.searchParams.get("service") || "";
-  const addons = (url.searchParams.get("addons") || "")
+  const rawAddons = (url.searchParams.get("addons") || "")
     .split(",")
     .map((s) => s.trim())
     .filter(Boolean);
@@ -30,7 +34,8 @@ export async function onRequestGet(context) {
     return json({ ok: false, message: "Bad date" }, 400);
   }
 
-  // Job length includes a travel buffer kept free after the job.
+  // Drop add-ons not offered with this service, then size the job.
+  const addons = validAddons(service, rawAddons);
   const minutes = serviceMinutes(service, addons);
   const buffer = AVAILABILITY.travelBufferMin;
   const block = minutes + buffer;

--- a/functions/api/availability.js
+++ b/functions/api/availability.js
@@ -1,0 +1,107 @@
+// Cloudflare Pages Function — GET /api/availability?date=YYYY-MM-DD&service=KEY&addons=k1,k2
+//
+// Phase 2 of the booking system. Returns the list of bookable start times for a
+// given day, computed from:
+//   • the estimated job duration (service + add-ons, from booking.mjs),
+//   • Gustavo's working hours + travel buffer (booking.mjs AVAILABILITY),
+//   • his real calendar busy blocks (Google Calendar FreeBusy API).
+//
+// Response: { ok, minutes, slots: ["09:00","09:30",...] }  (slots in local time)
+// On any backend failure it returns { ok:false } and the frontend falls back to
+// the Phase 1 "request a time window" flow — so the form always works.
+
+import { AVAILABILITY, serviceMinutes } from "../../src/config/booking.mjs";
+import { getAccessToken } from "./_google.js";
+import { tzOffsetMinutes, localToUtcMs, msToLocalHHMM } from "./_time.js";
+
+const TZ = AVAILABILITY.timeZone;
+
+export async function onRequestGet(context) {
+  const { request, env } = context;
+  const url = new URL(request.url);
+  const date = url.searchParams.get("date"); // YYYY-MM-DD (local)
+  const service = url.searchParams.get("service") || "";
+  const addons = (url.searchParams.get("addons") || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date || "")) {
+    return json({ ok: false, message: "Bad date" }, 400);
+  }
+
+  // Job length includes a travel buffer kept free after the job.
+  const minutes = serviceMinutes(service, addons);
+  const buffer = AVAILABILITY.travelBufferMin;
+  const block = minutes + buffer;
+
+  // Working window for this weekday.
+  const weekday = new Date(`${date}T12:00:00Z`).getUTCDay();
+  const hours = AVAILABILITY.hours[weekday];
+  if (!hours) return json({ ok: true, minutes, slots: [] }); // closed that day
+
+  const offset = tzOffsetMinutes(TZ, date); // NY offset for that date (handles DST)
+  const openMs = localToUtcMs(date, hours.open, offset);
+  const closeMs = localToUtcMs(date, hours.close, offset);
+
+  // Earliest allowed start (lead time) and advance-booking ceiling.
+  const now = Date.now();
+  const earliest = now + AVAILABILITY.minLeadMin * 60000;
+  const latestDay = now + AVAILABILITY.maxAdvanceDays * 86400000;
+  if (openMs > latestDay) return json({ ok: true, minutes, slots: [] });
+
+  // Busy blocks from Gustavo's calendar (best effort; no creds → no busy data).
+  let busy = [];
+  try {
+    busy = await freeBusy(env, openMs, closeMs);
+  } catch {
+    return json({ ok: false, message: "calendar unavailable" }, 502);
+  }
+  // Expand each busy block by the buffer so jobs aren't scheduled back-to-back.
+  const blocked = busy.map((b) => [b[0] - buffer * 60000, b[1] + buffer * 60000]);
+
+  const step = AVAILABILITY.slotStepMin * 60000;
+  const jobMs = minutes * 60000;
+  const slots = [];
+  for (let start = openMs; start + jobMs <= closeMs; start += step) {
+    const end = start + jobMs;
+    if (start < earliest) continue; // too soon
+    const clashes = blocked.some((b) => start < b[1] && end > b[0]);
+    if (!clashes) slots.push(msToLocalHHMM(start, offset));
+  }
+
+  return json({ ok: true, minutes, slots });
+}
+
+// freeBusy + json helpers below; timezone helpers live in ./_time.js.
+
+// ── Google Calendar FreeBusy ──
+async function freeBusy(env, fromMs, toMs) {
+  const calId = env.GOOGLE_CALENDAR_ID;
+  const token = await getAccessToken(env);
+  if (!calId || !token) return [];
+  const res = await fetch("https://www.googleapis.com/calendar/v3/freeBusy", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      timeMin: new Date(fromMs).toISOString(),
+      timeMax: new Date(toMs).toISOString(),
+      items: [{ id: calId }],
+    }),
+  });
+  if (!res.ok) throw new Error("freebusy failed");
+  const j = await res.json();
+  const cal = j.calendars && j.calendars[calId];
+  const periods = (cal && cal.busy) || [];
+  return periods.map((p) => [Date.parse(p.start), Date.parse(p.end)]);
+}
+
+function json(obj, status) {
+  return new Response(JSON.stringify(obj), {
+    status: status || 200,
+    headers: { "content-type": "application/json" },
+  });
+}

--- a/src/components/BookingForm.astro
+++ b/src/components/BookingForm.astro
@@ -1,9 +1,14 @@
 ---
-// Booking request form.
-// Submits as JSON to the Cloudflare Pages Function at /api/appointment, which
-//   1) emails the request to contact@route95mobilecardetailing.com (Web3Forms), and
-//   2) drops a tentative event on Gustavo's Google Calendar.
-// See functions/api/appointment.js for the backend + required env vars.
+// Booking form with live availability (Phase 2).
+// Service tiers, add-ons and vehicle types are rendered from the single source
+// of truth in src/config/booking.mjs (stable keys → correct in EN and ES).
+//
+// Flow: the customer fills their details + picks a service/add-ons + a date.
+// We then ask /api/availability for real open start times (computed from job
+// duration + Gustavo's calendar) and show them as buttons. Picking one books
+// that exact slot. If no slot is available or the lookup fails, the form still
+// submits as an open "request" (handled by /api/appointment).
+import { SERVICES, ADDONS, VEHICLES, AVAILABILITY } from "../config/booking.mjs";
 
 interface Props {
   lang?: "en" | "es";
@@ -15,47 +20,22 @@ const t = {
     heading: "Request an Appointment",
     intro:
       "Tell us where and when — we'll confirm by phone or text. No upfront payment, and every add-on is optional.",
-    subject: "New appointment request — Route95",
     name: "Full name",
     phone: "Phone",
     address: "Service address (street & city)",
     addressPh: "123 Main St, Fort Lauderdale",
     date: "Preferred date",
-    time: "Preferred time",
-    timeOpts: [
-      "Morning (9AM–12PM)",
-      "Afternoon (12–3PM)",
-      "Late afternoon (3–6PM)",
-      "Flexible",
-    ],
     service: "Service",
-    serviceOpts: [
-      "Quick Wash — exterior refresh ($40–$60)",
-      "Fresh Start — interior + exterior ($80–$110)",
-      "Complete Clean — full detail ($140–$170)",
-      "Premium Refresh — deep detail ($400–$460)",
-      "Not sure — recommend for me",
-    ],
     vehicle: "Vehicle type",
-    vehicleOpts: ["Sedan", "SUV / Crossover", "Truck / Van", "Other"],
     addons: "Add-ons (optional)",
-    addonList: [
-      "Door Jambs ($20)",
-      "Vacuum Trunk ($20)",
-      "Pet Hair Removal ($25)",
-      "Floor Mat Cleaning ($25)",
-      "Bug & Tar Removal ($30)",
-      "Trim Restoration ($30)",
-      "Odor Removal ($40)",
-      "Steam Cleaning ($50)",
-      "Car Waxing (from $60)",
-      "Carpet Shampooing (from $60)",
-      "Leather Cleaning & Conditioning (from $75)",
-      "Clay Bar Treatment (from $75)",
-      "Seat Shampooing (from $75)",
-      "Engine Bay Cleaning ($75–$150)",
-    ],
     notes: "Anything else? (gate code, special requests…)",
+    chooseTime: "Choose a start time",
+    loading: "Loading available times…",
+    noSlots:
+      "No open times that day — pick another date, or submit without a time and we'll arrange it.",
+    loadError:
+      "Couldn't load times. You can still submit and we'll confirm by phone.",
+    durationTpl: "Estimated time: about {min} min",
     submit: "Request appointment",
     sending: "Sending…",
     required: "* Required",
@@ -68,47 +48,22 @@ const t = {
     heading: "Solicita tu cita",
     intro:
       "Dinos dónde y cuándo — confirmamos por teléfono o mensaje. Sin pago por adelantado, y cada adicional es opcional.",
-    subject: "Nueva solicitud de cita — Route95",
     name: "Nombre completo",
     phone: "Teléfono",
     address: "Dirección del servicio (calle y ciudad)",
     addressPh: "123 Main St, Fort Lauderdale",
     date: "Fecha preferida",
-    time: "Hora preferida",
-    timeOpts: [
-      "Mañana (9AM–12PM)",
-      "Tarde (12–3PM)",
-      "Última hora (3–6PM)",
-      "Flexible",
-    ],
     service: "Servicio",
-    serviceOpts: [
-      "Quick Wash — lavado exterior ($40–$60)",
-      "Fresh Start — interior + exterior ($80–$110)",
-      "Complete Clean — detallado completo ($140–$170)",
-      "Premium Refresh — detallado profundo ($400–$460)",
-      "No estoy seguro — recomiéndame",
-    ],
     vehicle: "Tipo de vehículo",
-    vehicleOpts: ["Sedán", "SUV / Crossover", "Camioneta / Van", "Otro"],
     addons: "Adicionales (opcional)",
-    addonList: [
-      "Marcos de Puertas ($20)",
-      "Aspirado de Cajuela ($20)",
-      "Eliminación de Pelo de Mascota ($25)",
-      "Limpieza de Tapetes ($25)",
-      "Eliminación de Insectos y Brea ($30)",
-      "Restauración de Molduras ($30)",
-      "Eliminación de Olores ($40)",
-      "Limpieza y Acondicionamiento de Cuero (desde $75)",
-      "Tratamiento con Barra de Arcilla (desde $75)",
-      "Limpieza a Vapor ($50)",
-      "Lavado de Alfombras (desde $60)",
-      "Encerado de Auto (desde $60)",
-      "Lavado de Asientos (desde $75)",
-      "Limpieza de Motor ($75–$150)",
-    ],
     notes: "¿Algo más? (código de acceso, peticiones…)",
+    chooseTime: "Elige una hora de inicio",
+    loading: "Cargando horarios disponibles…",
+    noSlots:
+      "No hay horarios ese día — elige otra fecha, o envía sin hora y lo coordinamos.",
+    loadError:
+      "No se pudieron cargar los horarios. Puedes enviar igual y confirmamos por teléfono.",
+    durationTpl: "Tiempo estimado: aprox. {min} min",
     submit: "Solicitar cita",
     sending: "Enviando…",
     required: "* Obligatorio",
@@ -133,6 +88,11 @@ const labelCls = "block text-sm font-semibold text-[#0f2a4a] mb-1";
     data-success={t.success}
     data-error={t.error}
     data-sending={t.sending}
+    data-loading={t.loading}
+    data-noslots={t.noSlots}
+    data-loaderror={t.loadError}
+    data-duration={t.durationTpl}
+    data-maxadvance={AVAILABILITY.maxAdvanceDays}
     data-lang={lang}
     class="space-y-5"
   >
@@ -148,11 +108,11 @@ const labelCls = "block text-sm font-semibold text-[#0f2a4a] mb-1";
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-5">
       <div>
         <label class={labelCls} for="bf-name">{t.name} *</label>
-        <input id="bf-name" class={inputCls} type="text" name={t.name} required autocomplete="name" />
+        <input id="bf-name" class={inputCls} type="text" name="name" required autocomplete="name" />
       </div>
       <div>
         <label class={labelCls} for="bf-phone">{t.phone} *</label>
-        <input id="bf-phone" class={inputCls} type="tel" name={t.phone} required autocomplete="tel" />
+        <input id="bf-phone" class={inputCls} type="tel" name="phone" required autocomplete="tel" />
       </div>
     </div>
 
@@ -162,7 +122,7 @@ const labelCls = "block text-sm font-semibold text-[#0f2a4a] mb-1";
         id="bf-address"
         class={inputCls}
         type="text"
-        name={t.address}
+        name="address"
         placeholder={t.addressPh}
         required
         autocomplete="street-address"
@@ -171,31 +131,17 @@ const labelCls = "block text-sm font-semibold text-[#0f2a4a] mb-1";
 
     <div class="grid grid-cols-1 sm:grid-cols-2 gap-5">
       <div>
-        <label class={labelCls} for="bf-date">{t.date} *</label>
-        <input id="bf-date" class={inputCls} type="date" name={t.date} required />
-      </div>
-      <div>
-        <label class={labelCls} for="bf-time">{t.time} *</label>
-        <select id="bf-time" class={inputCls} name={t.time} required>
-          <option value="" disabled selected>{t.selectPh}</option>
-          {t.timeOpts.map((o) => <option value={o}>{o}</option>)}
-        </select>
-      </div>
-    </div>
-
-    <div class="grid grid-cols-1 sm:grid-cols-2 gap-5">
-      <div>
         <label class={labelCls} for="bf-service">{t.service} *</label>
-        <select id="bf-service" class={inputCls} name={t.service} required>
+        <select id="bf-service" class={inputCls} name="service" required>
           <option value="" disabled selected>{t.selectPh}</option>
-          {t.serviceOpts.map((o) => <option value={o}>{o}</option>)}
+          {SERVICES.map((s) => <option value={s.key}>{s[lang]}</option>)}
         </select>
       </div>
       <div>
         <label class={labelCls} for="bf-vehicle">{t.vehicle}</label>
-        <select id="bf-vehicle" class={inputCls} name={t.vehicle}>
+        <select id="bf-vehicle" class={inputCls} name="vehicle">
           <option value="" disabled selected>{t.selectPh}</option>
-          {t.vehicleOpts.map((o) => <option value={o}>{o}</option>)}
+          {VEHICLES.map((v) => <option value={v.key}>{v[lang]}</option>)}
         </select>
       </div>
     </div>
@@ -203,23 +149,37 @@ const labelCls = "block text-sm font-semibold text-[#0f2a4a] mb-1";
     <fieldset>
       <legend class={labelCls}>{t.addons}</legend>
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
-        {t.addonList.map((addon) => (
+        {ADDONS.map((addon) => (
           <label class="flex items-center gap-3 rounded-lg border border-gray-200 px-4 py-2.5 cursor-pointer hover:bg-gray-50">
             <input
               type="checkbox"
-              name={addon}
-              value="Yes"
+              name="addon"
+              value={addon.key}
               class="h-5 w-5 flex-shrink-0 rounded border-gray-300 text-[#0f2a4a] focus:ring-[#0f2a4a]"
             />
-            <span class="text-sm text-gray-700">{addon}</span>
+            <span class="text-sm text-gray-700">{addon[lang]}</span>
           </label>
         ))}
       </div>
     </fieldset>
 
     <div>
+      <label class={labelCls} for="bf-date">{t.date} *</label>
+      <input id="bf-date" class={inputCls} type="date" name="date" required />
+    </div>
+
+    <!-- Live availability — populated once a service + date are chosen -->
+    <div id="bf-slots-wrap" class="hidden">
+      <label class={labelCls}>{t.chooseTime}</label>
+      <p id="bf-duration" class="text-xs text-gray-500 mb-2"></p>
+      <div id="bf-slots" class="grid grid-cols-3 sm:grid-cols-4 gap-2"></div>
+      <p id="bf-slots-msg" class="text-sm text-gray-600 mt-1"></p>
+      <input type="hidden" id="bf-start" name="startTime" value="" />
+    </div>
+
+    <div>
       <label class={labelCls} for="bf-notes">{t.notes}</label>
-      <textarea id="bf-notes" class={inputCls} name={t.notes} rows="3"></textarea>
+      <textarea id="bf-notes" class={inputCls} name="notes" rows="3"></textarea>
     </div>
 
     <p class="text-xs text-gray-400">{t.required}</p>
@@ -245,13 +205,122 @@ const labelCls = "block text-sm font-semibold text-[#0f2a4a] mb-1";
     var byId = function (id) {
       return document.getElementById(id);
     };
-    var optText = function (el) {
-      return el && el.selectedIndex > 0 ? el.options[el.selectedIndex].text : "";
-    };
-    // Selects share the same option order across EN/ES, so index → stable key.
-    var keyFrom = function (el, keys) {
-      return el && el.selectedIndex > 0 ? keys[el.selectedIndex - 1] || "" : "";
-    };
+
+    var dateEl = byId("bf-date");
+    var serviceEl = byId("bf-service");
+    var slotsWrap = byId("bf-slots-wrap");
+    var slotsBox = byId("bf-slots");
+    var slotsMsg = byId("bf-slots-msg");
+    var durationEl = byId("bf-duration");
+    var startEl = byId("bf-start");
+
+    function ymd(d) {
+      return (
+        d.getFullYear() +
+        "-" +
+        String(d.getMonth() + 1).padStart(2, "0") +
+        "-" +
+        String(d.getDate()).padStart(2, "0")
+      );
+    }
+    // Restrict the date picker to today … today + maxAdvanceDays (visitor's clock).
+    var today = new Date();
+    var maxAdvance = parseInt(form.dataset.maxadvance || "30", 10);
+    var maxDate = new Date(today.getTime() + maxAdvance * 86400000);
+    dateEl.min = ymd(today);
+    dateEl.max = ymd(maxDate);
+
+    function checkedAddonKeys() {
+      var keys = [];
+      form
+        .querySelectorAll('fieldset input[type="checkbox"]:checked')
+        .forEach(function (c) {
+          keys.push(c.value);
+        });
+      return keys;
+    }
+
+    function clearSlots() {
+      slotsBox.innerHTML = "";
+      slotsMsg.textContent = "";
+      durationEl.textContent = "";
+      startEl.value = "";
+    }
+
+    var reqSeq = 0;
+    async function refreshSlots() {
+      var service = serviceEl.value;
+      var date = dateEl.value;
+      if (!service || !date) {
+        slotsWrap.classList.add("hidden");
+        clearSlots();
+        return;
+      }
+      slotsWrap.classList.remove("hidden");
+      clearSlots();
+      slotsMsg.textContent = form.dataset.loading;
+
+      var addons = checkedAddonKeys().join(",");
+      var url =
+        "/api/availability?date=" +
+        encodeURIComponent(date) +
+        "&service=" +
+        encodeURIComponent(service) +
+        "&addons=" +
+        encodeURIComponent(addons);
+
+      var seq = ++reqSeq;
+      try {
+        var res = await fetch(url, { headers: { Accept: "application/json" } });
+        var json = await res.json();
+        if (seq !== reqSeq) return; // a newer request superseded this one
+        if (!res.ok || !json.ok) {
+          slotsMsg.textContent = form.dataset.loaderror;
+          return;
+        }
+        if (typeof json.minutes === "number") {
+          durationEl.textContent = form.dataset.duration.replace(
+            "{min}",
+            json.minutes
+          );
+        }
+        if (!json.slots || !json.slots.length) {
+          slotsMsg.textContent = form.dataset.noslots;
+          return;
+        }
+        slotsMsg.textContent = "";
+        json.slots.forEach(function (slot) {
+          var b = document.createElement("button");
+          b.type = "button";
+          b.textContent = slot;
+          b.dataset.slot = slot;
+          b.className =
+            "rounded-lg border border-gray-300 px-2 py-2 text-sm text-gray-800 hover:border-[#0f2a4a] hover:bg-gray-50 transition";
+          b.addEventListener("click", function () {
+            startEl.value = slot;
+            slotsBox.querySelectorAll("button").forEach(function (x) {
+              x.className =
+                "rounded-lg border border-gray-300 px-2 py-2 text-sm text-gray-800 hover:border-[#0f2a4a] hover:bg-gray-50 transition";
+            });
+            b.className =
+              "rounded-lg border-2 border-[#0f2a4a] bg-[#0f2a4a] text-white px-2 py-2 text-sm font-semibold transition";
+          });
+          slotsBox.appendChild(b);
+        });
+      } catch (err) {
+        if (seq !== reqSeq) return;
+        slotsMsg.textContent = form.dataset.loaderror;
+      }
+    }
+
+    serviceEl.addEventListener("change", refreshSlots);
+    dateEl.addEventListener("change", refreshSlots);
+    form
+      .querySelectorAll('fieldset input[type="checkbox"]')
+      .forEach(function (c) {
+        c.addEventListener("change", refreshSlots);
+      });
+
     form.addEventListener("submit", async function (e) {
       e.preventDefault();
       var original = btn.textContent;
@@ -259,42 +328,17 @@ const labelCls = "block text-sm font-semibold text-[#0f2a4a] mb-1";
       btn.textContent = sending;
       status.className = "hidden";
       try {
-        var addons = [];
-        form
-          .querySelectorAll('fieldset input[type="checkbox"]:checked')
-          .forEach(function (c) {
-            addons.push(c.name);
-          });
         var honeypot = form.querySelector('input[name="botcheck"]');
         var payload = {
           lang: form.dataset.lang || "en",
           name: byId("bf-name").value.trim(),
           phone: byId("bf-phone").value.trim(),
           address: byId("bf-address").value.trim(),
-          date: byId("bf-date").value,
-          timeKey: keyFrom(byId("bf-time"), [
-            "morning",
-            "afternoon",
-            "late",
-            "flexible",
-          ]),
-          timeLabel: optText(byId("bf-time")),
-          serviceKey: keyFrom(byId("bf-service"), [
-            "quick",
-            "fresh",
-            "complete",
-            "premium",
-            "unsure",
-          ]),
-          serviceLabel: optText(byId("bf-service")),
-          vehicleKey: keyFrom(byId("bf-vehicle"), [
-            "sedan",
-            "suv",
-            "truck",
-            "other",
-          ]),
-          vehicleLabel: optText(byId("bf-vehicle")),
-          addons: addons,
+          date: dateEl.value,
+          serviceKey: serviceEl.value,
+          vehicleKey: byId("bf-vehicle").value,
+          addonKeys: checkedAddonKeys(),
+          startTime: startEl.value,
           notes: byId("bf-notes").value.trim(),
           botcheck: !!(honeypot && honeypot.checked),
         };
@@ -306,6 +350,8 @@ const labelCls = "block text-sm font-semibold text-[#0f2a4a] mb-1";
         var json = await res.json();
         if (!json.success) throw new Error(json.message || "fail");
         form.reset();
+        slotsWrap.classList.add("hidden");
+        clearSlots();
         status.textContent = form.dataset.success;
         status.className =
           "mt-4 rounded-lg p-4 text-sm bg-green-50 text-green-800 border border-green-200";

--- a/src/components/BookingForm.astro
+++ b/src/components/BookingForm.astro
@@ -77,6 +77,17 @@ const t = {
 const inputCls =
   "w-full rounded-lg border border-gray-300 px-4 py-3 text-gray-900 focus:border-[#0f2a4a] focus:ring-2 focus:ring-[#0f2a4a]/20 outline-none transition";
 const labelCls = "block text-sm font-semibold text-[#0f2a4a] mb-1";
+
+// Short note for add-ons gated to specific services (e.g. odor → Premium only).
+const requiresNote = (addon) => {
+  if (!addon.requires || !addon.requires.length) return "";
+  const names = addon.requires.map(
+    (k) => (SERVICES.find((s) => s.key === k)?.[lang] || k).split(" — ")[0]
+  );
+  return lang === "es"
+    ? `Solo con ${names.join(" / ")}`
+    : `${names.join(" / ")} only`;
+};
 ---
 
 <div>
@@ -150,14 +161,22 @@ const labelCls = "block text-sm font-semibold text-[#0f2a4a] mb-1";
       <legend class={labelCls}>{t.addons}</legend>
       <div class="grid grid-cols-1 sm:grid-cols-2 gap-2">
         {ADDONS.map((addon) => (
-          <label class="flex items-center gap-3 rounded-lg border border-gray-200 px-4 py-2.5 cursor-pointer hover:bg-gray-50">
+          <label
+            class="addon-item flex items-center gap-3 rounded-lg border border-gray-200 px-4 py-2.5 cursor-pointer hover:bg-gray-50"
+          >
             <input
               type="checkbox"
               name="addon"
               value={addon.key}
+              data-requires={addon.requires ? addon.requires.join(",") : ""}
               class="h-5 w-5 flex-shrink-0 rounded border-gray-300 text-[#0f2a4a] focus:ring-[#0f2a4a]"
             />
-            <span class="text-sm text-gray-700">{addon[lang]}</span>
+            <span class="text-sm text-gray-700">
+              {addon[lang]}
+              {requiresNote(addon) && (
+                <span class="block text-xs text-gray-400">{requiresNote(addon)}</span>
+              )}
+            </span>
           </label>
         ))}
       </div>
@@ -313,13 +332,35 @@ const labelCls = "block text-sm font-semibold text-[#0f2a4a] mb-1";
       }
     }
 
-    serviceEl.addEventListener("change", refreshSlots);
+    // Gate add-ons restricted to certain services (data-requires), e.g. odor → Premium.
+    function applyAddonGating() {
+      var service = serviceEl.value;
+      form
+        .querySelectorAll('fieldset input[type="checkbox"]')
+        .forEach(function (c) {
+          var req = (c.dataset.requires || "")
+            .split(",")
+            .filter(Boolean);
+          var allowed = req.length === 0 || req.indexOf(service) !== -1;
+          c.disabled = !allowed;
+          if (!allowed) c.checked = false;
+          var item = c.closest(".addon-item");
+          if (item) item.classList.toggle("opacity-40", !allowed);
+          if (item) item.classList.toggle("pointer-events-none", !allowed);
+        });
+    }
+
+    serviceEl.addEventListener("change", function () {
+      applyAddonGating();
+      refreshSlots();
+    });
     dateEl.addEventListener("change", refreshSlots);
     form
       .querySelectorAll('fieldset input[type="checkbox"]')
       .forEach(function (c) {
         c.addEventListener("change", refreshSlots);
       });
+    applyAddonGating();
 
     form.addEventListener("submit", async function (e) {
       e.preventDefault();

--- a/src/config/booking.mjs
+++ b/src/config/booking.mjs
@@ -45,13 +45,13 @@ export const ADDONS = [
   // detail (full interior + odor = ~2h total). Modeled as an add-on for now;
   // dependency rule still TBD. minutes = the extra it adds on top of the service.
   { key: "odor",           minutes: 120, en: "Odor Removal ($40)",                          es: "Eliminación de Olores ($40)" }, // PENDING decision
-  { key: "steam",          minutes: 45,  en: "Steam Cleaning ($50)",                        es: "Limpieza a Vapor ($50)" },
-  { key: "waxing",         minutes: 90,  en: "Car Waxing (from $60)",                       es: "Encerado de Auto (desde $60)" },
-  { key: "carpet-shampoo", minutes: 45,  en: "Carpet Shampooing (from $60)",                es: "Lavado de Alfombras (desde $60)" },
-  { key: "leather",        minutes: 30,  en: "Leather Cleaning & Conditioning (from $75)",  es: "Limpieza y Acondicionamiento de Cuero (desde $75)" },
-  { key: "clay-bar",       minutes: 120, en: "Clay Bar Treatment (from $75)",               es: "Tratamiento con Barra de Arcilla (desde $75)" },
-  { key: "seat-shampoo",   minutes: 45,  en: "Seat Shampooing (from $75)",                  es: "Lavado de Asientos (desde $75)" },
-  { key: "engine-bay",     minutes: 45,  en: "Engine Bay Cleaning ($75–$150)",              es: "Limpieza de Motor ($75–$150)" },
+  { key: "steam",          minutes: 45,  en: "Steam Cleaning ($50)",                        es: "Limpieza a Vapor ($50)" }, // Gustavo: 45 (full interior steam)
+  { key: "waxing",         minutes: 60,  en: "Car Waxing (from $85)",                       es: "Encerado de Auto (desde $85)" }, // Gustavo: machine, 1h+, from $85 — service page text TBD
+  { key: "carpet-shampoo", minutes: 45,  en: "Carpet Shampooing (from $60)",                es: "Lavado de Alfombras (desde $60)" }, // Gustavo: 45
+  { key: "leather",        minutes: 60,  en: "Leather Cleaning & Conditioning (from $75)",  es: "Limpieza y Acondicionamiento de Cuero (desde $75)" }, // Gustavo: 1h
+  { key: "clay-bar",       minutes: 120, en: "Clay Bar Treatment (from $75)",               es: "Tratamiento con Barra de Arcilla (desde $75)" }, // pending
+  { key: "seat-shampoo",   minutes: 60,  en: "Seat Shampooing (from $75)",                  es: "Lavado de Asientos (desde $75)" }, // Gustavo: 1h+, from $75
+  { key: "engine-bay",     minutes: 45,  en: "Engine Bay Cleaning ($50–$80)",               es: "Limpieza de Motor ($50–$80)" }, // Gustavo: 45; hand $50 / steam $80 — service page price TBD
 ];
 
 export const VEHICLES = [
@@ -65,14 +65,15 @@ export const VEHICLES = [
 export const AVAILABILITY = {
   timeZone: "America/New_York",
   // Weekday 0=Sun … 6=Sat. Local working window per day, or null = closed.
+  // All hours confirmed by Gustavo on 2026-06-19.
   hours: {
-    0: null, // Sunday closed — placeholder, confirm with Gustavo
-    1: { open: "09:00", close: "18:00" }, // Mon–Fri 9–6 (confirmed)
+    0: { open: "09:00", close: "12:00" }, // Sunday 9am–12pm
+    1: { open: "09:00", close: "18:00" }, // Mon–Fri 9am–6pm
     2: { open: "09:00", close: "18:00" },
     3: { open: "09:00", close: "18:00" },
     4: { open: "09:00", close: "18:00" },
     5: { open: "09:00", close: "18:00" },
-    6: { open: "09:00", close: "16:00" }, // Saturday — placeholder, confirm
+    6: { open: "09:00", close: "18:00" }, // Saturday 9am–6pm
   },
   travelBufferMin: 30, // gap kept free before & after each job (mobile: travel + setup)
   slotStepMin: 30,     // offer start times every 30 minutes

--- a/src/config/booking.mjs
+++ b/src/config/booking.mjs
@@ -41,17 +41,19 @@ export const ADDONS = [
   { key: "floor-mats",     minutes: 20,  en: "Floor Mat Cleaning ($25)",                    es: "Limpieza de Tapetes ($25)" }, // Gustavo: 20
   { key: "bug-tar",        minutes: 10,  en: "Bug & Tar Removal ($30)",                     es: "Eliminación de Insectos y Brea ($30)" }, // Gustavo: 10 (application only)
   { key: "trim",           minutes: 20,  en: "Trim Restoration ($30)",                      es: "Restauración de Molduras ($30)" }, // Gustavo: 20
-  // Odor removal is NOT standalone per Gustavo: it must accompany a full interior
-  // detail (full interior + odor = ~2h total). Modeled as an add-on for now;
-  // dependency rule still TBD. minutes = the extra it adds on top of the service.
-  { key: "odor",           minutes: 120, en: "Odor Removal ($40)",                          es: "Eliminación de Olores ($40)" }, // PENDING decision
+  // Odor removal is NOT standalone: Gustavo only does it with a full detail.
+  // `requires` gates the add-on in the form to those service keys (Premium only).
+  { key: "odor",           minutes: 120, requires: ["premium"], en: "Odor Removal ($40)",   es: "Eliminación de Olores ($40)" }, // Gustavo: Premium only (full detailing)
   { key: "steam",          minutes: 45,  en: "Steam Cleaning ($50)",                        es: "Limpieza a Vapor ($50)" }, // Gustavo: 45 (full interior steam)
-  { key: "waxing",         minutes: 60,  en: "Car Waxing (from $85)",                       es: "Encerado de Auto (desde $85)" }, // Gustavo: machine, 1h+, from $85 — service page text TBD
+  // Waxing offered two ways — different price AND duration. Customer picks one.
+  { key: "wax-hand",       minutes: 60,  en: "Car Waxing — by hand (from $60)",             es: "Encerado a Mano (desde $60)" }, // Gustavo: hand $60; duration estimate — confirm
+  { key: "wax-machine",    minutes: 90,  en: "Car Waxing — machine polish (from $90)",      es: "Encerado a Máquina (desde $90)" }, // Gustavo: machine $90; duration estimate — confirm
   { key: "carpet-shampoo", minutes: 45,  en: "Carpet Shampooing (from $60)",                es: "Lavado de Alfombras (desde $60)" }, // Gustavo: 45
   { key: "leather",        minutes: 60,  en: "Leather Cleaning & Conditioning (from $75)",  es: "Limpieza y Acondicionamiento de Cuero (desde $75)" }, // Gustavo: 1h
   { key: "clay-bar",       minutes: 30,  en: "Clay Bar Treatment (from $75)",               es: "Tratamiento con Barra de Arcilla (desde $75)" }, // Gustavo: "desde 30min" (service page says 1–2h — confirm typical vs. min)
   { key: "seat-shampoo",   minutes: 60,  en: "Seat Shampooing (from $75)",                  es: "Lavado de Asientos (desde $75)" }, // Gustavo: 1h+, from $75
-  { key: "engine-bay",     minutes: 45,  en: "Engine Bay Cleaning ($50–$80)",               es: "Limpieza de Motor ($50–$80)" }, // Gustavo: 45; hand $50 / steam $80 — service page price TBD
+  { key: "wheel-cleaning", minutes: 60,  en: "Wheel & Rim Cleaning ($80 / 4 wheels)",       es: "Limpieza de Aros ($80 / 4 ruedas)" }, // Gustavo: 1h, $20/wheel
+  { key: "engine-bay",     minutes: 45,  en: "Engine Bay Cleaning ($50–$80)",               es: "Limpieza de Motor ($50–$80)" }, // Gustavo: 45; hand $50 / steam $80
 ];
 
 export const VEHICLES = [
@@ -80,6 +82,16 @@ export const AVAILABILITY = {
   minLeadMin: 120,     // confirmed: no booking within 2h (Gustavo recommends a day ahead)
   maxAdvanceDays: 30,  // confirmed: up to 30 days ahead
 };
+
+// Drop add-ons that aren't offered with the chosen service (e.g. odor needs
+// Premium). Also drops unknown keys. Use this server-side before trusting input.
+export function validAddons(serviceKey, addonKeys = []) {
+  return addonKeys.filter((k) => {
+    const a = ADDONS.find((x) => x.key === k);
+    if (!a) return false;
+    return !a.requires || a.requires.includes(serviceKey);
+  });
+}
 
 // Total estimated job length: base service + selected add-ons (minutes).
 export function serviceMinutes(serviceKey, addonKeys = []) {

--- a/src/config/booking.mjs
+++ b/src/config/booking.mjs
@@ -35,7 +35,7 @@ export const SERVICES = [
 ];
 
 export const ADDONS = [
-  { key: "door-jambs",     minutes: 15,  en: "Door Jambs ($20)",                            es: "Marcos de Puertas ($20)" },
+  { key: "door-jambs",     minutes: 15,  en: "Door Jambs ($20)",                            es: "Marcos de Puertas ($20)" }, // Gustavo: 15 estimate OK
   { key: "vacuum-trunk",   minutes: 10,  en: "Vacuum Trunk ($20)",                          es: "Aspirado de Cajuela ($20)" },
   { key: "pet-hair",       minutes: 40,  en: "Pet Hair Removal ($25)",                      es: "Eliminación de Pelo de Mascota ($25)" }, // Gustavo: 20–40
   { key: "floor-mats",     minutes: 20,  en: "Floor Mat Cleaning ($25)",                    es: "Limpieza de Tapetes ($25)" }, // Gustavo: 20
@@ -50,7 +50,7 @@ export const ADDONS = [
   { key: "wax-machine",    minutes: 60,  en: "Car Waxing — machine polish (from $90)",      es: "Encerado a Máquina (desde $90)" }, // Gustavo: machine $90, 1h min
   { key: "carpet-shampoo", minutes: 45,  en: "Carpet Shampooing (from $60)",                es: "Lavado de Alfombras (desde $60)" }, // Gustavo: 45
   { key: "leather",        minutes: 60,  en: "Leather Cleaning & Conditioning (from $75)",  es: "Limpieza y Acondicionamiento de Cuero (desde $75)" }, // Gustavo: 1h
-  { key: "clay-bar",       minutes: 30,  en: "Clay Bar Treatment (from $75)",               es: "Tratamiento con Barra de Arcilla (desde $75)" }, // Gustavo: "desde 30min" (service page says 1–2h — confirm typical vs. min)
+  { key: "clay-bar",       minutes: 45,  en: "Clay Bar Treatment (from $75)",               es: "Tratamiento con Barra de Arcilla (desde $75)" }, // Gustavo: minimum 45 min (service page → 1h)
   { key: "seat-shampoo",   minutes: 60,  en: "Seat Shampooing (from $75)",                  es: "Lavado de Asientos (desde $75)" }, // Gustavo: 1h+, from $75
   { key: "wheel-cleaning", minutes: 60,  en: "Wheel & Rim Cleaning ($80 / 4 wheels)",       es: "Limpieza de Aros ($80 / 4 ruedas)" }, // Gustavo: 1h, $20/wheel
   { key: "engine-bay",     minutes: 45,  en: "Engine Bay Cleaning ($50–$80)",               es: "Limpieza de Motor ($50–$80)" }, // Gustavo: 45; hand $50 / steam $80

--- a/src/config/booking.mjs
+++ b/src/config/booking.mjs
@@ -46,8 +46,8 @@ export const ADDONS = [
   { key: "odor",           minutes: 120, requires: ["premium"], en: "Odor Removal ($40)",   es: "Eliminación de Olores ($40)" }, // Gustavo: Premium only (full detailing)
   { key: "steam",          minutes: 45,  en: "Steam Cleaning ($50)",                        es: "Limpieza a Vapor ($50)" }, // Gustavo: 45 (full interior steam)
   // Waxing offered two ways — different price AND duration. Customer picks one.
-  { key: "wax-hand",       minutes: 60,  en: "Car Waxing — by hand (from $60)",             es: "Encerado a Mano (desde $60)" }, // Gustavo: hand $60; duration estimate — confirm
-  { key: "wax-machine",    minutes: 90,  en: "Car Waxing — machine polish (from $90)",      es: "Encerado a Máquina (desde $90)" }, // Gustavo: machine $90; duration estimate — confirm
+  { key: "wax-hand",       minutes: 45,  en: "Car Waxing — by hand (from $60)",             es: "Encerado a Mano (desde $60)" }, // Gustavo: hand $60, 45 min
+  { key: "wax-machine",    minutes: 60,  en: "Car Waxing — machine polish (from $90)",      es: "Encerado a Máquina (desde $90)" }, // Gustavo: machine $90, 1h min
   { key: "carpet-shampoo", minutes: 45,  en: "Carpet Shampooing (from $60)",                es: "Lavado de Alfombras (desde $60)" }, // Gustavo: 45
   { key: "leather",        minutes: 60,  en: "Leather Cleaning & Conditioning (from $75)",  es: "Limpieza y Acondicionamiento de Cuero (desde $75)" }, // Gustavo: 1h
   { key: "clay-bar",       minutes: 30,  en: "Clay Bar Treatment (from $75)",               es: "Tratamiento con Barra de Arcilla (desde $75)" }, // Gustavo: "desde 30min" (service page says 1–2h — confirm typical vs. min)

--- a/src/config/booking.mjs
+++ b/src/config/booking.mjs
@@ -25,22 +25,26 @@
 //
 // >>> Gustavo can adjust ANY number below; nothing else needs to change. <<<
 
+// minutes confirmed by Gustavo on 2026-06-19.
 export const SERVICES = [
-  { key: "quick",    minutes: 30,  en: "Quick Wash — exterior refresh ($40–$60)",        es: "Quick Wash — lavado exterior ($40–$60)" },
-  { key: "fresh",    minutes: 60,  en: "Fresh Start — interior + exterior ($80–$110)",   es: "Fresh Start — interior + exterior ($80–$110)" },
+  { key: "quick",    minutes: 60,  en: "Quick Wash — exterior refresh ($40–$60)",        es: "Quick Wash — lavado exterior ($40–$60)" },
+  { key: "fresh",    minutes: 90,  en: "Fresh Start — interior + exterior ($80–$110)",   es: "Fresh Start — interior + exterior ($80–$110)" },
   { key: "complete", minutes: 120, en: "Complete Clean — full detail ($140–$170)",       es: "Complete Clean — detallado completo ($140–$170)" },
-  { key: "premium",  minutes: 210, en: "Premium Refresh — deep detail ($400–$460)",      es: "Premium Refresh — detallado profundo ($400–$460)" },
-  { key: "unsure",   minutes: 90,  en: "Not sure — recommend for me",                    es: "No estoy seguro — recomiéndame" },
+  { key: "premium",  minutes: 240, en: "Premium Refresh — deep detail ($400–$460)",      es: "Premium Refresh — detallado profundo ($400–$460)" },
+  { key: "unsure",   minutes: 90,  en: "Not sure — recommend for me",                    es: "No estoy seguro — recomiéndame" }, // estimate
 ];
 
 export const ADDONS = [
   { key: "door-jambs",     minutes: 15,  en: "Door Jambs ($20)",                            es: "Marcos de Puertas ($20)" },
   { key: "vacuum-trunk",   minutes: 10,  en: "Vacuum Trunk ($20)",                          es: "Aspirado de Cajuela ($20)" },
-  { key: "pet-hair",       minutes: 45,  en: "Pet Hair Removal ($25)",                      es: "Eliminación de Pelo de Mascota ($25)" },
-  { key: "floor-mats",     minutes: 15,  en: "Floor Mat Cleaning ($25)",                    es: "Limpieza de Tapetes ($25)" },
-  { key: "bug-tar",        minutes: 45,  en: "Bug & Tar Removal ($30)",                     es: "Eliminación de Insectos y Brea ($30)" },
-  { key: "trim",           minutes: 60,  en: "Trim Restoration ($30)",                      es: "Restauración de Molduras ($30)" },
-  { key: "odor",           minutes: 120, en: "Odor Removal ($40)",                          es: "Eliminación de Olores ($40)" },
+  { key: "pet-hair",       minutes: 40,  en: "Pet Hair Removal ($25)",                      es: "Eliminación de Pelo de Mascota ($25)" }, // Gustavo: 20–40
+  { key: "floor-mats",     minutes: 15,  en: "Floor Mat Cleaning ($25)",                    es: "Limpieza de Tapetes ($25)" }, // pending
+  { key: "bug-tar",        minutes: 10,  en: "Bug & Tar Removal ($30)",                     es: "Eliminación de Insectos y Brea ($30)" }, // Gustavo: 10 (application only)
+  { key: "trim",           minutes: 20,  en: "Trim Restoration ($30)",                      es: "Restauración de Molduras ($30)" }, // Gustavo: 20
+  // Odor removal is NOT standalone per Gustavo: it must accompany a full interior
+  // detail (full interior + odor = ~2h total). Modeled as an add-on for now;
+  // dependency rule still TBD. minutes = the extra it adds on top of the service.
+  { key: "odor",           minutes: 120, en: "Odor Removal ($40)",                          es: "Eliminación de Olores ($40)" }, // PENDING decision
   { key: "steam",          minutes: 45,  en: "Steam Cleaning ($50)",                        es: "Limpieza a Vapor ($50)" },
   { key: "waxing",         minutes: 90,  en: "Car Waxing (from $60)",                       es: "Encerado de Auto (desde $60)" },
   { key: "carpet-shampoo", minutes: 45,  en: "Carpet Shampooing (from $60)",                es: "Lavado de Alfombras (desde $60)" },

--- a/src/config/booking.mjs
+++ b/src/config/booking.mjs
@@ -62,13 +62,13 @@ export const AVAILABILITY = {
   timeZone: "America/New_York",
   // Weekday 0=Sun … 6=Sat. Local working window per day, or null = closed.
   hours: {
-    0: null, // Sunday closed
-    1: { open: "08:00", close: "18:00" },
-    2: { open: "08:00", close: "18:00" },
-    3: { open: "08:00", close: "18:00" },
-    4: { open: "08:00", close: "18:00" },
-    5: { open: "08:00", close: "18:00" },
-    6: { open: "09:00", close: "16:00" }, // Saturday shorter
+    0: null, // Sunday closed — placeholder, confirm with Gustavo
+    1: { open: "09:00", close: "18:00" }, // Mon–Fri 9–6 (confirmed)
+    2: { open: "09:00", close: "18:00" },
+    3: { open: "09:00", close: "18:00" },
+    4: { open: "09:00", close: "18:00" },
+    5: { open: "09:00", close: "18:00" },
+    6: { open: "09:00", close: "16:00" }, // Saturday — placeholder, confirm
   },
   travelBufferMin: 30, // gap kept free before & after each job (mobile: travel + setup)
   slotStepMin: 30,     // offer start times every 30 minutes

--- a/src/config/booking.mjs
+++ b/src/config/booking.mjs
@@ -38,7 +38,7 @@ export const ADDONS = [
   { key: "door-jambs",     minutes: 15,  en: "Door Jambs ($20)",                            es: "Marcos de Puertas ($20)" },
   { key: "vacuum-trunk",   minutes: 10,  en: "Vacuum Trunk ($20)",                          es: "Aspirado de Cajuela ($20)" },
   { key: "pet-hair",       minutes: 40,  en: "Pet Hair Removal ($25)",                      es: "Eliminación de Pelo de Mascota ($25)" }, // Gustavo: 20–40
-  { key: "floor-mats",     minutes: 15,  en: "Floor Mat Cleaning ($25)",                    es: "Limpieza de Tapetes ($25)" }, // pending
+  { key: "floor-mats",     minutes: 20,  en: "Floor Mat Cleaning ($25)",                    es: "Limpieza de Tapetes ($25)" }, // Gustavo: 20
   { key: "bug-tar",        minutes: 10,  en: "Bug & Tar Removal ($30)",                     es: "Eliminación de Insectos y Brea ($30)" }, // Gustavo: 10 (application only)
   { key: "trim",           minutes: 20,  en: "Trim Restoration ($30)",                      es: "Restauración de Molduras ($30)" }, // Gustavo: 20
   // Odor removal is NOT standalone per Gustavo: it must accompany a full interior
@@ -49,7 +49,7 @@ export const ADDONS = [
   { key: "waxing",         minutes: 60,  en: "Car Waxing (from $85)",                       es: "Encerado de Auto (desde $85)" }, // Gustavo: machine, 1h+, from $85 — service page text TBD
   { key: "carpet-shampoo", minutes: 45,  en: "Carpet Shampooing (from $60)",                es: "Lavado de Alfombras (desde $60)" }, // Gustavo: 45
   { key: "leather",        minutes: 60,  en: "Leather Cleaning & Conditioning (from $75)",  es: "Limpieza y Acondicionamiento de Cuero (desde $75)" }, // Gustavo: 1h
-  { key: "clay-bar",       minutes: 120, en: "Clay Bar Treatment (from $75)",               es: "Tratamiento con Barra de Arcilla (desde $75)" }, // pending
+  { key: "clay-bar",       minutes: 30,  en: "Clay Bar Treatment (from $75)",               es: "Tratamiento con Barra de Arcilla (desde $75)" }, // Gustavo: "desde 30min" (service page says 1–2h — confirm typical vs. min)
   { key: "seat-shampoo",   minutes: 60,  en: "Seat Shampooing (from $75)",                  es: "Lavado de Asientos (desde $75)" }, // Gustavo: 1h+, from $75
   { key: "engine-bay",     minutes: 45,  en: "Engine Bay Cleaning ($50–$80)",               es: "Limpieza de Motor ($50–$80)" }, // Gustavo: 45; hand $50 / steam $80 — service page price TBD
 ];
@@ -75,10 +75,10 @@ export const AVAILABILITY = {
     5: { open: "09:00", close: "18:00" },
     6: { open: "09:00", close: "18:00" }, // Saturday 9am–6pm
   },
-  travelBufferMin: 30, // gap kept free before & after each job (mobile: travel + setup)
+  travelBufferMin: 30, // confirmed: 30 min between vehicles (travel + setup)
   slotStepMin: 30,     // offer start times every 30 minutes
-  minLeadMin: 120,     // earliest bookable slot = now + 2 hours
-  maxAdvanceDays: 30,  // furthest a customer can book ahead
+  minLeadMin: 120,     // confirmed: no booking within 2h (Gustavo recommends a day ahead)
+  maxAdvanceDays: 30,  // confirmed: up to 30 days ahead
 };
 
 // Total estimated job length: base service + selected add-ons (minutes).

--- a/src/config/booking.mjs
+++ b/src/config/booking.mjs
@@ -1,0 +1,94 @@
+// Single source of truth for the booking system.
+// Imported by BOTH the frontend (src/components/BookingForm.astro) and the
+// Cloudflare Functions (functions/api/availability.js + appointment.js), so the
+// service list, durations and availability rules never drift between them.
+//
+// DURATIONS (minutes) are taken from the time stated on each service page,
+// using the UPPER bound of the stated range so we never under-book Gustavo.
+// Source quotes (EN service pages):
+//   Quick Wash ...... "20 to 30 minutes"            -> 30
+//   Fresh Start ..... "45 minutes to 1 hour"        -> 60
+//   Complete Clean .. "1.5 to 2 hours"              -> 120
+//   Premium Refresh . "2.5 to 3.5 hours"            -> 210
+//   Pet Hair ........ "30 to 45 minutes"            -> 45
+//   Bug & Tar ....... "30 to 45 minutes"            -> 45
+//   Trim ............ "30 to 90 minutes"            -> 60  (typical; range is wide)
+//   Odor ............ "1 to 2 hours" (general)      -> 120 (heavy smoke 3-4h: confirm manually)
+//   Steam ........... "about 45 minutes"            -> 45
+//   Car Waxing ...... "1 to 2 hours"                -> 90  (as add-on, prep often already done)
+//   Carpet Shampoo .. "30 to 45 minutes"            -> 45
+//   Leather ......... "approximately 30 minutes"    -> 30
+//   Clay Bar ........ "1 to 2 hours"                -> 120
+//   Seat Shampoo .... "about 45 minutes"            -> 45
+//   Engine Bay ...... "about 45 minutes"            -> 45
+//   Door Jambs / Vacuum Trunk / Floor Mats: no page time -> small estimates.
+//
+// >>> Gustavo can adjust ANY number below; nothing else needs to change. <<<
+
+export const SERVICES = [
+  { key: "quick",    minutes: 30,  en: "Quick Wash — exterior refresh ($40–$60)",        es: "Quick Wash — lavado exterior ($40–$60)" },
+  { key: "fresh",    minutes: 60,  en: "Fresh Start — interior + exterior ($80–$110)",   es: "Fresh Start — interior + exterior ($80–$110)" },
+  { key: "complete", minutes: 120, en: "Complete Clean — full detail ($140–$170)",       es: "Complete Clean — detallado completo ($140–$170)" },
+  { key: "premium",  minutes: 210, en: "Premium Refresh — deep detail ($400–$460)",      es: "Premium Refresh — detallado profundo ($400–$460)" },
+  { key: "unsure",   minutes: 90,  en: "Not sure — recommend for me",                    es: "No estoy seguro — recomiéndame" },
+];
+
+export const ADDONS = [
+  { key: "door-jambs",     minutes: 15,  en: "Door Jambs ($20)",                            es: "Marcos de Puertas ($20)" },
+  { key: "vacuum-trunk",   minutes: 10,  en: "Vacuum Trunk ($20)",                          es: "Aspirado de Cajuela ($20)" },
+  { key: "pet-hair",       minutes: 45,  en: "Pet Hair Removal ($25)",                      es: "Eliminación de Pelo de Mascota ($25)" },
+  { key: "floor-mats",     minutes: 15,  en: "Floor Mat Cleaning ($25)",                    es: "Limpieza de Tapetes ($25)" },
+  { key: "bug-tar",        minutes: 45,  en: "Bug & Tar Removal ($30)",                     es: "Eliminación de Insectos y Brea ($30)" },
+  { key: "trim",           minutes: 60,  en: "Trim Restoration ($30)",                      es: "Restauración de Molduras ($30)" },
+  { key: "odor",           minutes: 120, en: "Odor Removal ($40)",                          es: "Eliminación de Olores ($40)" },
+  { key: "steam",          minutes: 45,  en: "Steam Cleaning ($50)",                        es: "Limpieza a Vapor ($50)" },
+  { key: "waxing",         minutes: 90,  en: "Car Waxing (from $60)",                       es: "Encerado de Auto (desde $60)" },
+  { key: "carpet-shampoo", minutes: 45,  en: "Carpet Shampooing (from $60)",                es: "Lavado de Alfombras (desde $60)" },
+  { key: "leather",        minutes: 30,  en: "Leather Cleaning & Conditioning (from $75)",  es: "Limpieza y Acondicionamiento de Cuero (desde $75)" },
+  { key: "clay-bar",       minutes: 120, en: "Clay Bar Treatment (from $75)",               es: "Tratamiento con Barra de Arcilla (desde $75)" },
+  { key: "seat-shampoo",   minutes: 45,  en: "Seat Shampooing (from $75)",                  es: "Lavado de Asientos (desde $75)" },
+  { key: "engine-bay",     minutes: 45,  en: "Engine Bay Cleaning ($75–$150)",              es: "Limpieza de Motor ($75–$150)" },
+];
+
+export const VEHICLES = [
+  { key: "sedan", en: "Sedan",            es: "Sedán" },
+  { key: "suv",   en: "SUV / Crossover",  es: "SUV / Crossover" },
+  { key: "truck", en: "Truck / Van",      es: "Camioneta / Van" },
+  { key: "other", en: "Other",            es: "Otro" },
+];
+
+// Availability rules. >>> PLACEHOLDERS — Gustavo to confirm. <<<
+export const AVAILABILITY = {
+  timeZone: "America/New_York",
+  // Weekday 0=Sun … 6=Sat. Local working window per day, or null = closed.
+  hours: {
+    0: null, // Sunday closed
+    1: { open: "08:00", close: "18:00" },
+    2: { open: "08:00", close: "18:00" },
+    3: { open: "08:00", close: "18:00" },
+    4: { open: "08:00", close: "18:00" },
+    5: { open: "08:00", close: "18:00" },
+    6: { open: "09:00", close: "16:00" }, // Saturday shorter
+  },
+  travelBufferMin: 30, // gap kept free before & after each job (mobile: travel + setup)
+  slotStepMin: 30,     // offer start times every 30 minutes
+  minLeadMin: 120,     // earliest bookable slot = now + 2 hours
+  maxAdvanceDays: 30,  // furthest a customer can book ahead
+};
+
+// Total estimated job length: base service + selected add-ons (minutes).
+export function serviceMinutes(serviceKey, addonKeys = []) {
+  const svc = SERVICES.find((s) => s.key === serviceKey);
+  let total = svc ? svc.minutes : 0;
+  for (const k of addonKeys) {
+    const a = ADDONS.find((x) => x.key === k);
+    if (a) total += a.minutes;
+  }
+  return total;
+}
+
+// Localized label for a single key in one of the lists above.
+export function labelOf(list, key, lang = "en") {
+  const item = list.find((i) => i.key === key);
+  return item ? item[lang] || item.en : "";
+}


### PR DESCRIPTION
**Draft — depends on #81 (Phase 1).** Base is the Phase 1 branch; rebase onto `main` once #81 merges. Do not merge until Phase 1 is verified live AND Gustavo confirms the durations/hours below.

## What

Turns the booking form into a free self-service scheduler: the customer picks a service + add-ons + date, and we show **real open start times** computed from the estimated job duration and Gustavo's calendar (Google FreeBusy). Picking a slot books that exact block (tentative). No slot / lookup fails → falls back to an open request (Phase 1 behavior). Nothing ever breaks.

## Changes

- **`src/config/booking.mjs`** (new) — single source of truth: services, add-ons, vehicles (stable keys + EN/ES labels), per-service durations, and availability rules. Frontend and both Functions read from it.
- **`functions/api/availability.js`** (new) — `GET /api/availability?date&service&addons` → `{ ok, minutes, slots }`. Generates candidate starts within working hours, drops any overlapping a busy block (expanded by travel buffer). DST handled via the IANA zone (verified: EDT −240 / EST −300).
- **`functions/api/_google.js`, `_time.js`** (new) — shared service-account auth + timezone helpers.
- **`functions/api/appointment.js`** — books the exact slot `[start, start+duration]`; labels resolved server-side from keys (EN/ES correct). All-day fallback when no slot.
- **`BookingForm.astro`** — renders services/add-ons from config (**fixes an EN/ES add-on order mismatch** that would have mislabeled durations), live slot-button UI, graceful fallback.

## Durations (from service-page copy, upper bound) — pending Gustavo

Quick 30 · Fresh 60 · Complete 120 · Premium 210 · unsure 90* min.
Add-ons: pet-hair 45 · bug-tar 45 · trim 60 · odor 120 · steam 45 · waxing 90 · carpet 45 · leather 30 · clay 120 · seat 45 · engine 45 · door-jambs 15* · vacuum-trunk 10* · floor-mats 15* (*=estimate, no page time).

## Availability config (placeholders) — pending Gustavo

Mon–Fri 08–18, Sat 09–16, Sun closed · 30 min travel buffer · 30 min slot step · 2 h min lead · 30 days advance. All in `booking.mjs`.

## Testing

- `npm run build` ✓ (94 pages)
- `node --check` on all four Functions ✓
- Timezone + slot math unit-checked: DST offsets, local↔UTC round-trip, addMinutes, and slot generation (Premium 210 min → last Mon start 14:30) ✓
- Not live-tested end-to-end (needs deploy + Google creds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)