### PR TITLE
Seat shampooing: add 5 NW topic-coverage capsules + Process BLUF

### DIFF
--- a/src/pages/seat-shampooing-fort-lauderdale.astro
+++ b/src/pages/seat-shampooing-fort-lauderdale.astro
@@ -64,6 +64,46 @@ const faqSchema = {
         "@type": "Answer",
         "text": "Fabric seats absorb sweat, body oils, and spills that vacuuming alone cannot remove. Shampooing extracts what's trapped deep in the fibers."
       }
+    },
+    {
+      "@type": "Question",
+      "name": "Can Seat Shampooing Remove Old Stains and Odors?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes—hot water extraction removes most set-in stains along with the odors trapped underneath them. Fresh spills usually come out completely, while years-old coffee, sunscreen, or pet stains fade significantly and often disappear after enzyme pre-treatment."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "What's the Difference Between Seat Shampooing and Upholstery Extraction?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Shampooing works cleaning solution into the fabric to break down dirt; upholstery extraction is the step that pulls that solution—plus the loosened grime and moisture—back out with a machine. They're two halves of one process, and we do both on every visit."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can You Shampoo Seats and Carpets Together?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Yes—most customers add carpet shampooing to a seat service because the same extractor and cleaners handle both. Cleaning seats and carpets in one visit leaves the whole interior fresh and costs less than booking them separately."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "Can You Shampoo Leather Car Seats?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "No—leather seats should be cleaned and conditioned, not shampooed. Shampooing is for cloth and fabric upholstery; leather needs pH-balanced products that lift dirt and body oils without drying out or cracking the hide."
+      }
+    },
+    {
+      "@type": "Question",
+      "name": "How Often Should You Shampoo Your Car Seats?",
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": "Shampoo your car seats every 6–12 months in South Florida—more often if you have kids, pets, or drive to the beach regularly. The heat, humidity, and sand here work dirt and moisture into fabric faster than in drier climates."
+      }
     }
   ]
 };
@@ -142,7 +182,60 @@ const schemas = [serviceSchema, faqSchema];
       </section>
 
       <section>
+        <h2 class="text-2xl font-bold text-[#0f2a4a] mb-4">Can Seat Shampooing Remove Old Stains and Odors?</h2>
+        <p class="text-gray-600 mb-4">
+          <strong>Yes—hot water extraction removes most set-in stains along with the odors trapped underneath them. Fresh spills usually come out completely, while years-old coffee, sunscreen, or pet stains fade significantly and often disappear after enzyme pre-treatment.</strong>
+        </p>
+        <p class="text-gray-600">
+          Set-in stains need pre-treatment to break their bond with the fabric before we shampoo. For lingering smells from smoke, mildew, or spills, we pair shampooing with our <a href={`${base}odor-removal-fort-lauderdale/`} class="text-[#0f2a4a] font-semibold hover:text-[#c0c7cf]">odor removal service</a> to treat both the fabric and the air—removing the source instead of masking it. The deeper the buildup, the more extraction passes we make.
+        </p>
+      </section>
+
+      <section>
+        <h2 class="text-2xl font-bold text-[#0f2a4a] mb-4">What's the Difference Between Seat Shampooing and Upholstery Extraction?</h2>
+        <p class="text-gray-600 mb-4">
+          <strong>Shampooing works cleaning solution into the fabric to break down dirt; upholstery extraction is the step that pulls that solution—plus the loosened grime and moisture—back out with a machine. They're two halves of one process, and we do both on every visit.</strong>
+        </p>
+        <p class="text-gray-600">
+          The extraction pass matters most in Florida. A shampoo-only clean that leaves moisture behind can turn musty within a day in the humidity. Our hot water extractor injects and immediately vacuums, so seats come out damp rather than soaked and dry in 2–4 hours. Deep extraction is also what removes the dissolved dirt you'd otherwise leave sitting in the cushion.
+        </p>
+      </section>
+
+      <section>
+        <h2 class="text-2xl font-bold text-[#0f2a4a] mb-4">Can You Shampoo Seats and Carpets Together?</h2>
+        <p class="text-gray-600 mb-4">
+          <strong>Yes—most customers add carpet shampooing to a seat service because the same extractor and cleaners handle both. Cleaning seats and carpets in one visit leaves the whole interior fresh and costs less than booking them separately.</strong>
+        </p>
+        <p class="text-gray-600">
+          Floor carpets trap the sand, spilled drinks, and crumbs that vacuuming leaves behind, and they usually carry the same stains as the seats—beach sand, coffee, pet hair—so treating them together gives a more even result. Combined <a href={`${base}carpet-shampooing-fort-lauderdale/`} class="text-[#0f2a4a] font-semibold hover:text-[#c0c7cf]">seat and carpet shampooing</a> takes a little longer but dries in the same window. Ask for a combined quote when you book.
+        </p>
+      </section>
+
+      <section>
+        <h2 class="text-2xl font-bold text-[#0f2a4a] mb-4">Can You Shampoo Leather Car Seats?</h2>
+        <p class="text-gray-600 mb-4">
+          <strong>No—leather seats should be cleaned and conditioned, not shampooed. Shampooing is for cloth and fabric upholstery; leather needs pH-balanced products that lift dirt and body oils without drying out or cracking the hide.</strong>
+        </p>
+        <p class="text-gray-600">
+          Many Fort Lauderdale vehicles have mixed interiors—cloth inserts with leather bolsters. We handle both in one visit: shampoo and extract the fabric, then clean and condition the leather with our <a href={`${base}leather-cleaning-fort-lauderdale/`} class="text-[#0f2a4a] font-semibold hover:text-[#c0c7cf]">leather cleaning</a> and <a href={`${base}leather-conditioning-fort-lauderdale/`} class="text-[#0f2a4a] font-semibold hover:text-[#c0c7cf]">conditioning</a> service. Tell us your seat type when you book and we'll bring the right products.
+        </p>
+      </section>
+
+      <section>
+        <h2 class="text-2xl font-bold text-[#0f2a4a] mb-4">How Often Should You Shampoo Your Car Seats?</h2>
+        <p class="text-gray-600 mb-4">
+          <strong>Shampoo your car seats every 6–12 months in South Florida—more often if you have kids, pets, or drive to the beach regularly. The heat, humidity, and sand here work dirt and moisture into fabric faster than in drier climates.</strong>
+        </p>
+        <p class="text-gray-600">
+          A daily-driver family SUV usually needs it twice a year; a lightly used commuter can go a full year. When a musty smell returns or stains reappear, it's time. Pairing shampooing with <a href={`${base}fabric-protection-fort-lauderdale/`} class="text-[#0f2a4a] font-semibold hover:text-[#c0c7cf]">fabric protection</a> extends how long seats stay clean between services.
+        </p>
+      </section>
+
+      <section>
         <h2 class="text-2xl font-bold text-[#0f2a4a] mb-6">Our Seat Shampooing Process</h2>
+        <p class="text-gray-600 mb-4">
+          Our five-step process cleans, extracts, and dries your seats in a single visit—here's exactly what we do.
+        </p>
         <ProcessSteps steps={[
           { title: "Inspection", description: "We check your seats for stains, wear, and fabric type to choose the right approach." },
           { title: "Pre-Treatment", description: "Tough stains get treated with Chemical Guys Lightning Fast Stain Extractor. This enzyme-based cleaner breaks down coffee, food, and organic stains before we shampoo." },


### PR DESCRIPTION
## Why
The seat-shampooing page was the thinnest, worst-ranked service page in GSC (748 words, 3 capsules, **avg pos 23.5**). NeuronWriter confirmed a real content gap — content score **71 vs. 78** top competitor — unlike auto-upholstery where we already lead on content and the gap is off-page. This closes the on-page half.

## What
Adds **5 Q&A capsules** (written to the CLAUDE.md capsule spec — H2 = real query, first 40–60 words answer it, one specific fact), each closing an NW term cluster that was dragging Headings (63%) and Terms (58%):

| Capsule | Closes |
|---|---|
| Can Seat Shampooing Remove Old Stains and Odors? | stain/odor cluster |
| What's the Difference Between Seat Shampooing and Upholstery Extraction? | extraction cluster (was 0-count, blue-dot terms) |
| Can You Shampoo Seats and Carpets Together? | carpet cluster (`carpet`, `carpet shampoo`, `seat and carpet`) |
| Can You Shampoo Leather Car Seats? | leather; +2 internal links |
| How Often Should You Shampoo Your Car Seats? | frequency gap (NW topic-coverage 20%) |

Plus a **BLUF intro line** under "Our Seat Shampooing Process" (was 0% BLUF).

- `FAQPage` schema extended **3 → 8 pairs** (under the 10-pair cap), matching visible Q&A exactly.
- Body content ~748 → in-spec.
- **Deliberately skipped** the DIY "best products / tools" NW questions — informational intent that would cannibalize the commercial page.

## Notes
- On-page only. Per our diagnosis, the pos-23 ranking is still gated by the map pack + porting the ES `/es/lavado-de-asientos` authority (ranks pos 7.3); this removes content as the blocker.
- `npm run build` passes; all 5 JSON-LD blocks validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)