### PR TITLE
Add Bing Webmaster Tools verification meta tag

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -210,6 +210,9 @@ const organizationSchema = {
   <meta name="description" content={description}>
   <meta name="robots" content="index, follow">
 
+  <!-- Bing Webmaster Tools verification -->
+  <meta name="msvalidate.01" content="C1BCAD4E5EBB1A9ACB041D31AA42F2AC" />
+
   <!-- Preload critical images -->
   <link rel="preload" as="image" type="image/webp" href="/logo-transparent-mobile.webp" fetchpriority="high" />
   {preloadImages.map(src => (


### PR DESCRIPTION
## What

Adds the Bing Webmaster Tools verification `<meta>` tag to the shared `<head>` in `BaseLayout.astro`.

```html
<meta name="msvalidate.01" content="C1BCAD4E5EBB1A9ACB041D31AA42F2AC" />
```

## Why

Required to verify domain ownership in Bing Webmaster Tools. The tag must be present in the home page `<head>`.

## Notes

- Placed in the shared `BaseLayout`, so it renders on the home page (what Bing checks) and every other page — harmless site-wide.
- Sits inside `<head>`, before `</head>`, as required.
- After merge + deploy, click **Verify** in Bing Webmaster Tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)